### PR TITLE
Second attempt implementing azure service bus timeouts for nimbus

### DIFF
--- a/src/Nimbus.Autofac/AutofacTimeoutBroker.cs
+++ b/src/Nimbus.Autofac/AutofacTimeoutBroker.cs
@@ -1,0 +1,27 @@
+﻿using Autofac;
+using Nimbus.InfrastructureContracts;
+using Nimbus.MessageContracts;
+
+namespace Nimbus.Autofac
+{
+    public class AutofacTimeoutBroker : ITimeoutBroker
+    {
+        private readonly ILifetimeScope _lifetimeScope;
+
+        public AutofacTimeoutBroker(ILifetimeScope lifetimeScope)
+        {
+            _lifetimeScope = lifetimeScope;
+        }
+
+        public void Dispatch<TBusTimeout>(TBusTimeout busCommand) where TBusTimeout : IBusTimeout
+        {
+            using (var scope = _lifetimeScope.BeginLifetimeScope())
+            {
+                var type = typeof(IHandleTimeouts<TBusTimeout>);
+
+                var handler = (IHandleTimeouts<IBusTimeout>)scope.Resolve(type);
+                handler.Timeout(busCommand);
+            }
+        }
+    }
+}

--- a/src/Nimbus.Autofac/Nimbus.Autofac.csproj
+++ b/src/Nimbus.Autofac/Nimbus.Autofac.csproj
@@ -48,6 +48,7 @@
     <Compile Include="AutofacMulticastEventBroker.cs" />
     <Compile Include="AutofacMulticastRequestBroker.cs" />
     <Compile Include="AutofacRequestBroker.cs" />
+    <Compile Include="AutofacTimeoutBroker.cs" />
     <Compile Include="NimbusContainerBuilderExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Nimbus.Autofac/NimbusContainerBuilderExtensions.cs
+++ b/src/Nimbus.Autofac/NimbusContainerBuilderExtensions.cs
@@ -23,6 +23,10 @@ namespace Nimbus.Autofac
             builder.RegisterType<AutofacCommandBroker>()
                    .AsImplementedInterfaces()
                    .SingleInstance();
+            
+            builder.RegisterType<AutofacTimeoutBroker>()
+                   .AsImplementedInterfaces()
+                   .SingleInstance();
 
             builder.RegisterType<AutofacRequestBroker>()
                    .AsImplementedInterfaces()

--- a/src/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
+++ b/src/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
@@ -63,6 +63,9 @@
     <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\SlowBlackBallRequestHandler.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\WhenSendingASixSecondMulticastRequest.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\WhenSendingATwoSecondMulticastRequest.cs" />
+    <Compile Include="Tests\SimpleRequestTimeoutTests\TimeoutHandlers\SomeTimeoutHandler.cs" />
+    <Compile Include="Tests\SimpleRequestTimeoutTests\MessageContracts\SomeTimeout.cs" />
+    <Compile Include="Tests\SimpleRequestTimeoutTests\WhenRequestingATimeoutOnTheBus.cs" />
     <Compile Include="Tests\SimplePubSubTests\EventHandlers\SomeCombinedEventHandler.cs" />
     <Compile Include="Tests\SimplePubSubTests\EventHandlers\SomeCompetingEventHandler.cs" />
     <Compile Include="Tests\SimplePubSubTests\MessageContracts\SomeEventWeHandleViaMulticastAndCompetition.cs" />

--- a/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/MessageContracts/SomeTimeout.cs
+++ b/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/MessageContracts/SomeTimeout.cs
@@ -1,0 +1,8 @@
+﻿using Nimbus.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.SimpleRequestTimeoutTests.MessageContracts
+{
+    public class SomeTimeout : IBusTimeout
+    {
+    }
+}

--- a/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/TimeoutHandlers/SomeTimeoutHandler.cs
+++ b/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/TimeoutHandlers/SomeTimeoutHandler.cs
@@ -1,0 +1,12 @@
+﻿using Nimbus.InfrastructureContracts;
+using Nimbus.IntegrationTests.Tests.SimpleRequestTimeoutTests.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.SimpleRequestTimeoutTests.TimeoutHandlers
+{
+    public class SomeTimeoutHandler : IHandleTimeouts<SomeTimeout>
+    {
+        public void Timeout(SomeTimeout busTimeout)
+        {
+        }
+    }
+}

--- a/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/WhenRequestingATimeoutOnTheBus.cs
+++ b/src/Nimbus.IntegrationTests/Tests/SimpleRequestTimeoutTests/WhenRequestingATimeoutOnTheBus.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nimbus.IntegrationTests.Extensions;
+using Nimbus.IntegrationTests.Tests.SimpleRequestTimeoutTests.MessageContracts;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.IntegrationTests.Tests.SimpleRequestTimeoutTests
+{
+    [TestFixture]
+    public class WhenRequestingATimeoutOnTheBus : SpecificationForBus
+    {
+        public override async Task WhenAsync()
+        {
+            var someTimeout = new SomeTimeout();
+            await Subject.Defer(TimeSpan.FromSeconds(30), someTimeout);
+            TimeSpan.FromSeconds(35).SleepUntil(() => MessageBroker.AllReceivedMessages.Any());
+        }
+
+        [Test]
+        public void TheTimeoutBrokerShouldReceiveThatTimeout()
+        {
+            MessageBroker.AllReceivedMessages.OfType<SomeTimeout>().Count().ShouldBe(1);
+        }
+
+        [Test]
+        public void TheCorrectNumberOfTotalMessagesShouldHaveBeenObserved()
+        {
+            MessageBroker.AllReceivedMessages.Count().ShouldBe(1);
+        }
+    }
+}

--- a/src/Nimbus.MessageContracts/IBusTimeout.cs
+++ b/src/Nimbus.MessageContracts/IBusTimeout.cs
@@ -1,0 +1,6 @@
+﻿namespace Nimbus.MessageContracts
+{
+    public interface IBusTimeout
+    {
+    }
+}

--- a/src/Nimbus.MessageContracts/Nimbus.MessageContracts.csproj
+++ b/src/Nimbus.MessageContracts/Nimbus.MessageContracts.csproj
@@ -46,6 +46,7 @@
     <Compile Include="IBusEvent.cs" />
     <Compile Include="IBusRequest.cs" />
     <Compile Include="IBusResponse.cs" />
+    <Compile Include="IBusTimeout.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -11,12 +11,15 @@ namespace Nimbus.Configuration
         internal string InstanceName { get; set; }
         internal string ConnectionString { get; set; }
         internal ICommandBroker CommandBroker { get; set; }
+        internal ITimeoutBroker TimeoutBroker { get; set; }
         internal IRequestBroker RequestBroker { get; set; }
         internal IMulticastRequestBroker MulticastRequestBroker { get; set; }
         internal IMulticastEventBroker MulticastEventBroker { get; set; }
         internal ICompetingEventBroker CompetingEventBroker { get; set; }
         internal Type[] CommandHandlerTypes { get; set; }
         internal Type[] CommandTypes { get; set; }
+        internal Type[] TimeoutHandlerTypes { get; set; }
+        internal Type[] TimeoutTypes { get; set; }
         internal Type[] RequestHandlerTypes { get; set; }
         internal Type[] RequestTypes { get; set; }
         internal Type[] MulticastEventHandlerTypes { get; set; }

--- a/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
@@ -42,6 +42,12 @@ namespace Nimbus.Configuration
             configuration.CommandBroker = commandBroker;
             return configuration;
         }
+        
+        public static BusBuilderConfiguration WithTimeoutBroker(this BusBuilderConfiguration configuration, ITimeoutBroker timeoutBroker)
+        {
+            configuration.TimeoutBroker = timeoutBroker;
+            return configuration;
+        }
 
         public static BusBuilderConfiguration WithRequestBroker(this BusBuilderConfiguration configuration, IRequestBroker requestBroker)
         {
@@ -59,6 +65,9 @@ namespace Nimbus.Configuration
         {
             configuration.CommandHandlerTypes = typeProvider.CommandHandlerTypes.ToArray();
             configuration.CommandTypes = typeProvider.CommandTypes.ToArray();
+            
+            configuration.TimeoutHandlerTypes = typeProvider.TimeoutHandlerTypes.ToArray();
+            configuration.TimeoutTypes = typeProvider.TimeoutTypes.ToArray();
 
             configuration.RequestHandlerTypes = typeProvider.RequestHandlerTypes.ToArray();
             configuration.RequestTypes = typeProvider.RequestTypes.ToArray();

--- a/src/Nimbus/IBus.cs
+++ b/src/Nimbus/IBus.cs
@@ -10,6 +10,10 @@ namespace Nimbus
     {
         Task Send<TBusCommand>(TBusCommand busCommand) where TBusCommand : IBusCommand;
 
+        Task Defer<TBusTimeout>(TimeSpan delay, TBusTimeout busTimeout) where TBusTimeout : IBusTimeout;
+
+        Task Defer<TBusTimeout>(DateTime processAt, TBusTimeout busTimeout) where TBusTimeout : IBusTimeout;
+
         Task<TResponse> Request<TRequest, TResponse>(BusRequest<TRequest, TResponse> busRequest)
             where TRequest : IBusRequest
             where TResponse : IBusResponse;

--- a/src/Nimbus/Infrastructure/AssemblyScanningTypeProvider.cs
+++ b/src/Nimbus/Infrastructure/AssemblyScanningTypeProvider.cs
@@ -14,6 +14,8 @@ namespace Nimbus.Infrastructure
         private readonly Lazy<Type[]> _allInstantiableTypesInScannedAssemblies;
         private readonly Lazy<Type[]> _commandHandlerTypes;
         private readonly Lazy<Type[]> _commandTypes;
+        private readonly Lazy<Type[]> _timeoutHandlerTypes;
+        private readonly Lazy<Type[]> _timeoutTypes;
         private readonly Lazy<Type[]> _multicastEventHandlerTypes;
         private readonly Lazy<Type[]> _competingEventHandlerTypes;
         private readonly Lazy<Type[]> _eventTypes;
@@ -32,6 +34,8 @@ namespace Nimbus.Infrastructure
             _allInstantiableTypesInScannedAssemblies = new Lazy<Type[]>(ScanAssembliesForInterestingTypes);
             _commandHandlerTypes = new Lazy<Type[]>(ScanForCommandHandlerTypes);
             _commandTypes = new Lazy<Type[]>(ScanForCommandTypes);
+            _timeoutHandlerTypes = new Lazy<Type[]>(ScanForTimeoutHandlerTypes);
+            _timeoutTypes = new Lazy<Type[]>(ScanForTimeoutTypes);
             _multicastEventHandlerTypes = new Lazy<Type[]>(ScanForMulticastEventHandlerTypes);
             _competingEventHandlerTypes = new Lazy<Type[]>(ScanForCompetingEventHandlerTypes);
             _eventTypes = new Lazy<Type[]>(ScanForEventTypes);
@@ -47,6 +51,16 @@ namespace Nimbus.Infrastructure
         public IEnumerable<Type> CommandTypes
         {
             get { return _commandTypes.Value; }
+        }
+
+        public IEnumerable<Type> TimeoutHandlerTypes
+        {
+            get { return _timeoutHandlerTypes.Value; }
+        }
+
+        public IEnumerable<Type> TimeoutTypes
+        {
+            get { return _timeoutTypes.Value; }
         }
 
         public IEnumerable<Type> MulticastEventHandlerTypes
@@ -95,6 +109,24 @@ namespace Nimbus.Infrastructure
         {
             var types = AllInstantiableTypesInScannedAssemblies
                 .Where(t => typeof (IBusCommand).IsAssignableFrom(t))
+                .ToArray();
+
+            return types;
+        }
+        
+        private Type[] ScanForTimeoutHandlerTypes()
+        {
+            var types = AllInstantiableTypesInScannedAssemblies
+                .Where(t => t.IsClosedTypeOf(typeof (IHandleTimeouts<>)))
+                .ToArray();
+
+            return types;
+        }
+
+        private Type[] ScanForTimeoutTypes()
+        {
+            var types = AllInstantiableTypesInScannedAssemblies
+                .Where(t => typeof (IBusTimeout).IsAssignableFrom(t))
                 .ToArray();
 
             return types;

--- a/src/Nimbus/Infrastructure/Timeouts/BusTimeoutSender.cs
+++ b/src/Nimbus/Infrastructure/Timeouts/BusTimeoutSender.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using Nimbus.MessageContracts;
+
+namespace Nimbus.Infrastructure.Timeouts
+{
+    internal class BusTimeoutSender : ITimeoutSender
+    {
+        private readonly IMessageSenderFactory _messageSenderFactory;
+        private readonly IClock _clock;
+
+        public BusTimeoutSender(IMessageSenderFactory messageSenderFactory, IClock clock)
+        {
+            _messageSenderFactory = messageSenderFactory;
+            _clock = clock;
+        }
+
+        public async Task Defer<TBusTimeout>(TimeSpan delay, IBusTimeout busTimeout)
+        {
+            var sender = _messageSenderFactory.GetMessageSender(typeof(TBusTimeout));
+            var message = new BrokeredMessage(busTimeout) { ScheduledEnqueueTimeUtc = _clock.UtcNow.Add(delay).DateTime };
+            await sender.SendBatchAsync(new[] { message });
+        }
+
+        public async Task Defer<TBusTimeout>(DateTime processAt, IBusTimeout busTimeout)
+        {
+            var sender = _messageSenderFactory.GetMessageSender(typeof(TBusTimeout));
+            var message = new BrokeredMessage(busTimeout) { ScheduledEnqueueTimeUtc = processAt };
+            await sender.SendBatchAsync(new[] { message });
+        }
+    }
+}

--- a/src/Nimbus/Infrastructure/Timeouts/ITimeoutSender.cs
+++ b/src/Nimbus/Infrastructure/Timeouts/ITimeoutSender.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nimbus.MessageContracts;
+
+namespace Nimbus.Infrastructure.Timeouts
+{
+    internal interface ITimeoutSender
+    {
+        Task Defer<TBusTimeout>(TimeSpan delay, IBusTimeout busTimeout);
+
+        Task Defer<TBusTimeout>(DateTime processAt, IBusTimeout busTimeout);
+    }
+}

--- a/src/Nimbus/Infrastructure/Timeouts/TimeoutMessagePump.cs
+++ b/src/Nimbus/Infrastructure/Timeouts/TimeoutMessagePump.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using Microsoft.ServiceBus.Messaging;
+using Nimbus.Extensions;
+using Nimbus.InfrastructureContracts;
+
+namespace Nimbus.Infrastructure.Timeouts
+{
+    public class TimeoutMessagePump : MessagePump
+    {
+        private readonly MessagingFactory _messagingFactory;
+        private readonly ITimeoutBroker _timeoutBroker;
+        private readonly Type _messageType;
+        private MessageReceiver _reciever;
+
+        public TimeoutMessagePump(MessagingFactory messagingFactory, ITimeoutBroker timeoutBroker, Type messageType, ILogger logger) : base(logger)
+        {
+            _messagingFactory = messagingFactory;
+            _timeoutBroker = timeoutBroker;
+            _messageType = messageType;
+        }
+
+        public override void Start()
+        {
+            var queueName = PathFactory.QueuePathFor(_messageType);
+            _reciever = _messagingFactory.CreateMessageReceiver(queueName);
+            base.Start();
+        }
+
+        public override void Stop()
+        {
+            if (_reciever != null) _reciever.Close();
+            base.Stop();
+        }
+
+        protected override BrokeredMessage[] ReceiveMessages()
+        {
+            return _reciever.ReceiveBatch(int.MaxValue, TimeSpan.FromSeconds(1)).ToArray();
+        }
+
+        protected override void PumpMessage(BrokeredMessage message)
+        {
+            var busTimeout = message.GetBody(_messageType);
+            _timeoutBroker.Dispatch((dynamic) busTimeout);
+        }
+    }
+}

--- a/src/Nimbus/InfrastructureContracts/IHandleTimeouts.cs
+++ b/src/Nimbus/InfrastructureContracts/IHandleTimeouts.cs
@@ -1,0 +1,9 @@
+﻿using Nimbus.MessageContracts;
+
+namespace Nimbus.InfrastructureContracts
+{
+    public interface IHandleTimeouts<TBusTimeout> where TBusTimeout : IBusTimeout
+    {
+        void Timeout(TBusTimeout busTimeout);
+    }
+}

--- a/src/Nimbus/InfrastructureContracts/ITimeoutBroker.cs
+++ b/src/Nimbus/InfrastructureContracts/ITimeoutBroker.cs
@@ -1,0 +1,9 @@
+﻿using Nimbus.MessageContracts;
+
+namespace Nimbus.InfrastructureContracts
+{
+    public interface ITimeoutBroker
+    {
+        void Dispatch<TBusTimeout>(TBusTimeout busCommand) where TBusTimeout : IBusTimeout;
+    }
+}

--- a/src/Nimbus/InfrastructureContracts/ITypeProvider.cs
+++ b/src/Nimbus/InfrastructureContracts/ITypeProvider.cs
@@ -7,6 +7,9 @@ namespace Nimbus.InfrastructureContracts
     {
         IEnumerable<Type> CommandHandlerTypes { get; }
         IEnumerable<Type> CommandTypes { get; }
+        
+        IEnumerable<Type> TimeoutHandlerTypes { get; }
+        IEnumerable<Type> TimeoutTypes { get; }
 
         IEnumerable<Type> MulticastEventHandlerTypes { get; }
         IEnumerable<Type> CompetingEventHandlerTypes { get; }

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -47,6 +47,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="InfrastructureContracts\IHandleTimeouts.cs" />
+    <Compile Include="InfrastructureContracts\ITimeoutBroker.cs" />
     <Compile Include="Infrastructure\AssemblyScanningTypeProvider.cs" />
     <Compile Include="Configuration\BusDebuggingConfiguration.cs" />
     <Compile Include="Configuration\BusDebuggingConfigurationExtensions.cs" />
@@ -68,6 +70,9 @@
     <Compile Include="Infrastructure\RequestResponse\MulticastRequestResponseCorrelationWrapper.cs" />
     <Compile Include="Infrastructure\Events\CompetingEventMessagePump.cs" />
     <Compile Include="Infrastructure\MessagePropertyKeys.cs" />
+    <Compile Include="Infrastructure\Timeouts\BusTimeoutSender.cs" />
+    <Compile Include="Infrastructure\Timeouts\TimeoutMessagePump.cs" />
+    <Compile Include="Infrastructure\Timeouts\ITimeoutSender.cs" />
     <Compile Include="PoisonMessages\IDeadLetterQueue.cs" />
     <Compile Include="PoisonMessages\IDeadLetterQueues.cs" />
     <Compile Include="PoisonMessages\DeadLetterQueue.cs" />


### PR DESCRIPTION
Based on setting BrokeredMessage.ScheduledEnqueueTimeUtc to when the message should be made available for processing.

Task Send<TBusCommand>(Timeout delay, TBusCommand busCommand)

The above example is a possible different approach, would be simpler but would not make it clear what the difference is between a timeout or a command.
