### PR TITLE
Added much simpler implementation for timeouts.

### DIFF
--- a/src/Nimbus/Bus.cs
+++ b/src/Nimbus/Bus.cs
@@ -41,6 +41,16 @@ namespace Nimbus
             await _commandSender.Send(busCommand);
         }
 
+        public async Task Defer<TBusCommand>(TimeSpan delay, TBusCommand busCommand) where TBusCommand : IBusCommand
+        {
+            await _commandSender.SendAt(delay, busCommand);
+        }
+
+        public async Task Defer<TBusCommand>(DateTimeOffset processAt, TBusCommand busCommand) where TBusCommand : IBusCommand
+        {
+            await _commandSender.SendAt(processAt, busCommand);
+        }
+
         public async Task<TResponse> Request<TRequest, TResponse>(IBusRequest<TRequest, TResponse> busRequest)
             where TRequest : IBusRequest<TRequest, TResponse>
             where TResponse : IBusResponse

--- a/src/Nimbus/Configuration/BusBuilder.cs
+++ b/src/Nimbus/Configuration/BusBuilder.cs
@@ -44,7 +44,7 @@ namespace Nimbus.Configuration
 
             var messageSenderFactory = new MessageSenderFactory(messagingFactory);
             var topicClientFactory = new TopicClientFactory(messagingFactory);
-            var commandSender = new BusCommandSender(messageSenderFactory);
+            var commandSender = new BusCommandSender(messageSenderFactory, clock);
             var requestSender = new BusRequestSender(messageSenderFactory, replyQueueName, requestResponseCorrelator, clock, configuration.DefaultTimeout);
             var multicastRequestSender = new BusMulticastRequestSender(topicClientFactory, replyQueueName, requestResponseCorrelator, clock);
             var eventSender = new BusEventSender(topicClientFactory);

--- a/src/Nimbus/IBus.cs
+++ b/src/Nimbus/IBus.cs
@@ -10,6 +10,10 @@ namespace Nimbus
     {
         Task Send<TBusCommand>(TBusCommand busCommand) where TBusCommand : IBusCommand;
 
+        Task Defer<TBusCommand>(TimeSpan delay, TBusCommand busCommand) where TBusCommand : IBusCommand;
+
+        Task Defer<TBusCommand>(DateTimeOffset processAt, TBusCommand busCommand) where TBusCommand : IBusCommand;
+
         Task<TResponse> Request<TRequest, TResponse>(IBusRequest<TRequest, TResponse> busRequest)
             where TRequest : IBusRequest<TRequest, TResponse>
             where TResponse : IBusResponse;

--- a/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 
 namespace Nimbus.Infrastructure.Commands
@@ -6,10 +7,12 @@ namespace Nimbus.Infrastructure.Commands
     internal class BusCommandSender : ICommandSender
     {
         private readonly IMessageSenderFactory _messageSenderFactory;
+        private readonly IClock _clock;
 
-        public BusCommandSender(IMessageSenderFactory messageSenderFactory)
+        public BusCommandSender(IMessageSenderFactory messageSenderFactory, IClock clock)
         {
             _messageSenderFactory = messageSenderFactory;
+            _clock = clock;
         }
 
         public async Task Send<TBusCommand>(TBusCommand busCommand)
@@ -17,6 +20,22 @@ namespace Nimbus.Infrastructure.Commands
             var sender = _messageSenderFactory.GetMessageSender(typeof (TBusCommand));
             var message = new BrokeredMessage(busCommand);
             await sender.SendBatchAsync(new[] {message});
+        }
+
+        public async Task SendAt<TBusCommand>(TimeSpan delay, TBusCommand busCommand)
+        {
+            await SendAt(_clock.UtcNow.Add(delay), busCommand);
+        }
+
+        public async Task SendAt<TBusCommand>(DateTimeOffset proccessAt, TBusCommand busCommand)
+        {
+            var sender = _messageSenderFactory.GetMessageSender(typeof(TBusCommand));
+            var message = new BrokeredMessage(busCommand)
+            {
+                ScheduledEnqueueTimeUtc = proccessAt.DateTime
+            };
+
+            await sender.SendBatchAsync(new[] { message });
         }
     }
 }

--- a/src/Nimbus/Infrastructure/Commands/ICommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/ICommandSender.cs
@@ -1,9 +1,14 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Nimbus.Infrastructure.Commands
 {
     internal interface ICommandSender
     {
         Task Send<TBusCommand>(TBusCommand busCommand);
+
+        Task SendAt<TBusCommand>(TimeSpan delay, TBusCommand busCommand);
+
+        Task SendAt<TBusCommand>(DateTimeOffset proccessAt, TBusCommand busCommand);
     }
 }


### PR DESCRIPTION
Based on setting BrokeredMessage.ScheduledEnqueueTimeUtc to when the message should be made available for processing.

Alternative implementation of PR #5
