### PR TITLE
Why can't the send interface on the bus look like this overload?

### DIFF
--- a/src/Nimbus/Bus.cs
+++ b/src/Nimbus/Bus.cs
@@ -43,6 +43,13 @@ namespace Nimbus
             return Task.Run(() => _commandSender.Send(busCommand));
         }
 
+        public Task Send(IBusCommand busCommand)
+        {
+            // We're explicitly invoking Task.Run in these facade methods to make sure that we break out of anyone else's
+            // synchronisation context and run this stuff only on thread pool threads.  -andrewh 24/1/2014
+            return Task.Run(() => _commandSender.Send(busCommand));
+        }
+
         public Task Defer<TBusCommand>(TimeSpan delay, TBusCommand busCommand) where TBusCommand : IBusCommand
         {
             return Task.Run(() => _commandSender.SendAt(delay, busCommand));

--- a/src/Nimbus/IBus.cs
+++ b/src/Nimbus/IBus.cs
@@ -10,6 +10,8 @@ namespace Nimbus
     {
         Task Send<TBusCommand>(TBusCommand busCommand) where TBusCommand : IBusCommand;
 
+        Task Send(IBusCommand busCommand);
+
         Task Defer<TBusCommand>(TimeSpan delay, TBusCommand busCommand) where TBusCommand : IBusCommand;
 
         Task Defer<TBusCommand>(DateTimeOffset processAt, TBusCommand busCommand) where TBusCommand : IBusCommand;

--- a/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 using Nimbus.Extensions;
+using Nimbus.MessageContracts;
 using Nimbus.MessageContracts.Exceptions;
 
 namespace Nimbus.Infrastructure.Commands
@@ -20,14 +21,24 @@ namespace Nimbus.Infrastructure.Commands
             _validCommandTypes = new HashSet<Type>(validCommandTypes);
         }
 
-        public async Task Send<TBusCommand>(TBusCommand busCommand)
+        public async Task Send<TBusCommand>(TBusCommand busCommand) where TBusCommand : IBusCommand
         {
-            if (!_validCommandTypes.Contains(typeof(TBusCommand)))
-                throw new BusException("The type {0} is not a recognised command type. Ensure it has been registered with the builder with the WithTypesFrom method.".FormatWith(typeof(TBusCommand).FullName));
+            await SendCommand(busCommand, typeof(TBusCommand));
+        }
 
-            var sender = _messageSenderFactory.GetMessageSender(typeof (TBusCommand));
+        private async Task SendCommand(IBusCommand busCommand, Type commandType)
+        {
+            if (!_validCommandTypes.Contains(commandType))
+                throw new BusException("The type {0} is not a recognised command type. Ensure it has been registered with the builder with the WithTypesFrom method.".FormatWith(commandType.FullName));
+
+            var sender = _messageSenderFactory.GetMessageSender(commandType);
             var message = new BrokeredMessage(busCommand);
-            await sender.SendBatchAsync(new[] {message});
+            await sender.SendBatchAsync(new[] { message });
+        }
+
+        public async Task Send(IBusCommand busCommand)
+        {
+            await SendCommand(busCommand, busCommand.GetType());
         }
 
         public async Task SendAt<TBusCommand>(TimeSpan delay, TBusCommand busCommand)

--- a/src/Nimbus/Infrastructure/Commands/ICommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/ICommandSender.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Nimbus.MessageContracts;
 
 namespace Nimbus.Infrastructure.Commands
 {
     internal interface ICommandSender
     {
-        Task Send<TBusCommand>(TBusCommand busCommand);
+        Task Send<TBusCommand>(TBusCommand busCommand) where TBusCommand : IBusCommand;
+
+        Task Send(IBusCommand busCommand);
 
         Task SendAt<TBusCommand>(TimeSpan delay, TBusCommand busCommand);
 


### PR DESCRIPTION
The use case for this is on my client I want to construct something like..

``` C#
var commands = new List<IBusCommand>() {new FirstCommand(), new SecondCommand()};
await Task.WhenAll(commands.Select(x => _bus.Send(x)));
```

At the moment when I do this, the generic parameter interepreted by the Send method on the IBus has been downcast to IBusCommand. This means that appropriate handlers can't be located and explosions.

Consider this PR a think piece - I haven't gone through to completion with the implementation. 

But I could do so if this is a valid direction?
