### PR TITLE
Pass up serialization exceptions

### DIFF
--- a/src/Nimbus/Infrastructure/AssemblyScanningTypeProvider.cs
+++ b/src/Nimbus/Infrastructure/AssemblyScanningTypeProvider.cs
@@ -152,10 +152,10 @@ namespace Nimbus.Infrastructure
         {
             AssertAllHandledMessageTypesAreIncludedDirectly();
             AssertThatWeWontDuplicateQueueNames();
-            AssertAllMessageTypesAreSerlizable();
+            AssertAllMessageTypesAreSerializable();
         }
 
-        private void AssertAllMessageTypesAreSerlizable()
+        private void AssertAllMessageTypesAreSerializable()
         {
             var messageTypes = CommandTypes
                 .Union(RequestTypes)
@@ -173,13 +173,13 @@ namespace Nimbus.Infrastructure
                         serializer.WriteObject(mem, instance);
                     }
                 }
-                catch (Exception)
+                catch (Exception exception)
                 {
                     var message = "The message contract type {0} is not serializable."
                         .FormatWith(
                             messageType.FullName);
 
-                    throw new BusException(message);
+                    throw new BusException(message, exception);
                 }    
             }
         }

--- a/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
+++ b/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
@@ -2,6 +2,7 @@
 using Nimbus.MessageContracts.Exceptions;
 using Nimbus.UnitTests.TestAssemblies.MessageContracts.Serialization;
 using NUnit.Framework;
+using Shouldly;
 
 namespace Nimbus.UnitTests.AssemblyScanningTests
 {
@@ -15,6 +16,16 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof(UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
 
             assemblyScanningTypeProvider.Verify();
+        }
+
+        [Test]
+        public void TheExceptionShouldIncludeAnInnerException()
+        {
+            var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof(UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
+
+            var exception = Assert.Throws<BusException>(() => assemblyScanningTypeProvider.Verify());
+
+            exception.InnerException.ShouldNotBe(null);
         }
     }
 }


### PR DESCRIPTION
When asserting message types can be serialized, pass the exception into the BusException's `InnerException`.

This helps with debugging where in the message's graph the serialization is failing, as sometimes the exception is actually useful.
