### PR TITLE
LogResponseWhenActuallyReceived

### DIFF
--- a/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
@@ -71,7 +71,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                           queuePath,
                           message.MessageId,
                           message.CorrelationId);
-            var response = responseCorrelationWrapper.WaitForResponse(timeout);
+            var response = await responseCorrelationWrapper.WaitForResponse(timeout);
             _logger.Info("Received response to {0} from {1} [MessageId:{2}, CorrelationId:{3}] in the form of {4}",
                          message.SafelyGetBodyTypeNameOrDefault(),
                          queuePath,
@@ -79,7 +79,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                          message.CorrelationId,
                          response.GetType().FullName);
 
-            return await response;
+            return response;
         }
     }
 }


### PR DESCRIPTION
A small change introduced in 14535fecf8badb7f84dbe0a7382284a9620f0cf1 means the "Received response" log is being written before the response is actually received. I was pretty sure the request should take longer than 0.001s to arrive! :p
