### PR TITLE
Watch for the completion of long running tasks

### DIFF
--- a/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
+++ b/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
@@ -61,7 +61,7 @@ namespace Nimbus.Infrastructure
 
         protected async Task<Task> AwaitCompletionInternal(Task handlerTask)
         {
-            var tasks = new List<Task> {handlerTask};
+            var tasks = new List<Task> { WaitForCompletion(handlerTask) };
 
             if (_longRunningHandler != null)
             {


### PR DESCRIPTION
The watcher was attempting to renew the message lock even though the message handler had completed since the _completed flag was never set.
