### PR TITLE
Watch for the completion of long running tasks 2

### DIFF
--- a/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
+++ b/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
@@ -63,6 +63,16 @@ namespace Nimbus.Infrastructure
         {
             var tasks = new List<Task> {handlerTask};
 
+#pragma warning disable 4014
+            handlerTask.ContinueWith(t =>
+#pragma warning restore 4014
+            {
+                lock (_mutex)
+                {
+                    _completed = true;
+                }
+            });
+
             if (_longRunningHandler != null)
             {
                 var watcherTask = Watch(_longRunningHandler, _message);
@@ -77,15 +87,6 @@ namespace Nimbus.Infrastructure
             }
 
             return firstTaskToComplete;
-        }
-
-        private async Task WaitForCompletion(Task handlerTask)
-        {
-            await Task.Run(async () => { await handlerTask; });
-            lock (_mutex)
-            {
-                _completed = true;
-            }
         }
 
         private async Task Watch(ILongRunningTask longRunningHandler, BrokeredMessage message)


### PR DESCRIPTION
The watcher was attempting to renew the message lock even though the message handler had completed since the _completed flag was never set. Doing this with a continuation instead of a wrapping task due to problems casting Task back to Task<T> for Request/Response handlers.
