### PR TITLE
AzureQueueManager.WarmUp and MessagePumpTypes

### DIFF
--- a/src/Nimbus/Configuration/BusBuilder.cs
+++ b/src/Nimbus/Configuration/BusBuilder.cs
@@ -81,7 +81,7 @@ namespace Nimbus.Configuration
                               messagePumps,
                               container.Resolve<DeadLetterQueues>());
 
-            bus.Starting += delegate { container.Resolve<AzureQueueManager>().WarmUp(); };
+            bus.Starting += delegate { };
 
             bus.Disposing += delegate
                              {


### PR DESCRIPTION
By calling `AzureQueueManager.WarmUp()` during the Starting event, all of the existing Queues/Topics/Subscriptions are queried. However, if I specify that I just want to wait for my ResponseQueue in `Bus.Start()`, I still pay the price of querying for all Topics and Subscriptions before `Bus.Start()` returns.

Allowing the Lazy evaluation of `_knownTopics` and `_knownSubscriptions` seems to be OK in our use cases.
