### PR TITLE
Startup bug: we weren't checking for multicast request topics when we we...

### DIFF
--- a/src/Nimbus/Bus.cs
+++ b/src/Nimbus/Bus.cs
@@ -151,9 +151,7 @@ namespace Nimbus
             if (!disposing) return;
 
             var handler = Disposing;
-            if (handler == null) return;
-
-            handler(this, EventArgs.Empty);
+            if (handler != null) handler(this, EventArgs.Empty);
         }
     }
 }

--- a/src/Nimbus/Extensions/TypeProviderExtensions.cs
+++ b/src/Nimbus/Extensions/TypeProviderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Nimbus.Handlers;
-using Nimbus.MessageContracts;
 
 namespace Nimbus.Extensions
 {
@@ -26,6 +25,26 @@ namespace Nimbus.Extensions
                                .ToArray();
         }
 
+        public static Type[] AllTypesHandledViaTopics(this ITypeProvider typeProvider)
+        {
+            var handlers = new Type[0]
+                .Union(typeProvider.MulticastEventHandlerTypes)
+                .Union(typeProvider.CompetingEventHandlerTypes)
+                .Union(typeProvider.MulticastRequestHandlerTypes)
+                .ToArray();
+
+            var handledEvents = handlers.SelectMany(hand => hand.GetInterfaces())
+                                        .Where(
+                                            i =>
+                                            i.IsClosedTypeOf(typeof (IHandleCompetingEvent<>)) ||
+                                            i.IsClosedTypeOf(typeof (IHandleMulticastEvent<>)) ||
+                                            i.IsClosedTypeOf(typeof (IHandleMulticastRequest<,>))
+                )
+                                        .SelectMany(i => i.GetGenericArguments());
+
+            return handledEvents.Distinct().ToArray();
+        }
+
         public static Type[] AllHandledEventTypes(this ITypeProvider typeProvider)
         {
             var handlers = new Type[0]
@@ -34,7 +53,7 @@ namespace Nimbus.Extensions
                 .ToArray();
 
             var handledEvents = handlers.SelectMany(hand => hand.GetInterfaces())
-                                        .Where(i => i.IsClosedTypeOf(typeof(IHandleCompetingEvent<>)) || i.IsClosedTypeOf(typeof(IHandleMulticastEvent<>)))
+                                        .Where(i => i.IsClosedTypeOf(typeof (IHandleCompetingEvent<>)) || i.IsClosedTypeOf(typeof (IHandleMulticastEvent<>)))
                                         .SelectMany(i => i.GetGenericArguments());
 
             return handledEvents.Distinct().ToArray();

--- a/src/Nimbus/Infrastructure/AzureQueueManager.cs
+++ b/src/Nimbus/Infrastructure/AzureQueueManager.cs
@@ -141,7 +141,7 @@ namespace Nimbus.Infrastructure
 
         private bool WeHaveAHandler(string topicPath)
         {
-            var paths = _typeProvider.AllHandledEventTypes().Select(PathFactory.TopicPathFor);
+            var paths = _typeProvider.AllTypesHandledViaTopics().Select(PathFactory.TopicPathFor);
             return paths.Contains(topicPath);
         }
 

--- a/src/Tests/Nimbus.UnitTests/Conventions/AllInterfacesInTheInfrastructureNamespace.cs
+++ b/src/Tests/Nimbus.UnitTests/Conventions/AllInterfacesInTheInfrastructureNamespace.cs
@@ -25,10 +25,11 @@ namespace Nimbus.UnitTests.Conventions
                 var referenceType = typeof (IMessagePump);
 
                 return referenceType.Assembly.GetTypes()
+                                    .Where(t => t.Namespace != null)
                                     .Where(t => t.Namespace == referenceType.Namespace || t.Namespace.StartsWith(referenceType.Namespace + "."))
                                     .Where(t => t.IsInterface)
                                     .Select(t => new TestCaseData(t)
-                                                .SetName(t.FullName)
+                                                     .SetName(t.FullName)
                     ).GetEnumerator();
             }
 


### PR DESCRIPTION
...re scanning for existing topics. Not a functional problem but would have slowed startup for apps with lots of multicast request handlers.
