### PR TITLE
Register and resolve interceptors consistently with Autofac

### DIFF
--- a/src/Extensions/Nimbus.Autofac/Configuration/NimbusContainerBuilderExtensions.cs
+++ b/src/Extensions/Nimbus.Autofac/Configuration/NimbusContainerBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Nimbus.Configuration
             builder.RegisterSource(new ContravariantRegistrationSource());
             typeProvider.InterceptorTypes
                         .Do(t => builder.RegisterType(t)
-                                        .AsImplementedInterfaces()
+                                        .AsSelf()
                                         .InstancePerLifetimeScope())
                         .Done();
 

--- a/src/Extensions/Nimbus.Autofac/Infrastructure/AutofacDependencyResolverScope.cs
+++ b/src/Extensions/Nimbus.Autofac/Infrastructure/AutofacDependencyResolverScope.cs
@@ -23,6 +23,11 @@ namespace Nimbus.Autofac.Infrastructure
             return _lifetimeScope.ResolveNamed<TComponent>(componentName);
         }
 
+        public object Resolve(Type componentType)
+        {
+            return _lifetimeScope.Resolve(componentType);
+        }
+
         public object Resolve(Type componentType, string componentName)
         {
             return _lifetimeScope.ResolveNamed(componentName, componentType);

--- a/src/Extensions/Nimbus.Windsor/Infrastructure/WindsorDependencyResolverScope.cs
+++ b/src/Extensions/Nimbus.Windsor/Infrastructure/WindsorDependencyResolverScope.cs
@@ -26,6 +26,11 @@ namespace Nimbus.Windsor.Infrastructure
             return _kernel.Resolve<TComponent>(componentName);
         }
 
+        public object Resolve(Type componentType)
+        {
+            return _kernel.Resolve(componentType);
+        }
+
         public object Resolve(Type componentType, string componentName)
         {
             return _kernel.Resolve(componentName, componentType);

--- a/src/Nimbus.InfrastructureContracts/DependencyResolution/IDependencyResolverScope.cs
+++ b/src/Nimbus.InfrastructureContracts/DependencyResolution/IDependencyResolverScope.cs
@@ -5,6 +5,7 @@ namespace Nimbus.DependencyResolution
     public interface IDependencyResolverScope : ICreateChildScopes, IDisposable
     {
         TComponent Resolve<TComponent>(string componentName);
+        object Resolve(Type componentType);
         object Resolve(Type componentType, string componentName);
     }
 }

--- a/src/Nimbus/Infrastructure/DependencyResolution/DependencyResolverScope.cs
+++ b/src/Nimbus/Infrastructure/DependencyResolution/DependencyResolverScope.cs
@@ -46,6 +46,17 @@ namespace Nimbus.Infrastructure.DependencyResolution
             return component;
         }
 
+        public object Resolve(Type componentType)
+        {
+            var component = ComponentsOfType(componentType)
+                .Select(CreateInstance)
+                .First();
+
+            Track(component);
+
+            return component;
+        }
+
         public object Resolve(Type componentType, string componentName)
         {
             var component = ComponentsOfType(componentType)

--- a/src/Nimbus/Interceptors/Outbound/IOutboundInterceptorFactory.cs
+++ b/src/Nimbus/Interceptors/Outbound/IOutboundInterceptorFactory.cs
@@ -22,7 +22,7 @@ namespace Nimbus.Interceptors.Outbound
         {
             return _globalOutboundInterceptorTypes
                 .Value
-                .Select(t => (IOutboundInterceptor) scope.Resolve(t, t.FullName))
+                .Select(t => (IOutboundInterceptor) scope.Resolve(t))
                 .ToArray();
         }
     }

--- a/src/Tests/Nimbus.IntegrationTests/Tests/ThroughputTests/Infrastructure/FakeChildScope.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/ThroughputTests/Infrastructure/FakeChildScope.cs
@@ -23,6 +23,11 @@ namespace Nimbus.IntegrationTests.Tests.ThroughputTests.Infrastructure
             return (TComponent) (object) _fakeHandler;
         }
 
+        public object Resolve(Type componentType)
+        {
+            throw new NotImplementedException();
+        }
+
         public object Resolve(Type componentType, string componentName)
         {
             throw new NotImplementedException();

--- a/src/Tests/Nimbus.UnitTests/InterceptorTests/WhenBuildingABusWithAutofacAndInterceptors.cs
+++ b/src/Tests/Nimbus.UnitTests/InterceptorTests/WhenBuildingABusWithAutofacAndInterceptors.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Microsoft.ServiceBus.Messaging;
+using Nimbus.Configuration;
+using Nimbus.Configuration.Settings;
+using Nimbus.DependencyResolution;
+using Nimbus.Interceptors.Outbound;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nimbus.UnitTests.InterceptorTests
+{
+    [TestFixture]
+    public class WhenRegisteringInterceptorsWithAutofac
+    {
+        class DummyInterceptor : IOutboundInterceptor
+        {
+            public Task Decorate(BrokeredMessage brokeredMessage, object busMessage)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Test]
+        public void TheyShouldBeResolvable()
+        {
+            var interceptorTypes = new[] {typeof (DummyInterceptor)};
+
+            var builder = new ContainerBuilder();
+            var typeProvider = Substitute.For<ITypeProvider>();
+            typeProvider.InterceptorTypes.Returns(interceptorTypes);
+
+            builder.RegisterNimbus(typeProvider);
+
+            using (var container = builder.Build())
+            using (var dependencyResolver = container.Resolve<IDependencyResolver>())
+            using (var scope = dependencyResolver.CreateChildScope())
+            {
+                var interceptorSetting = new GlobalOutboundInterceptorTypesSetting {
+                    Value = interceptorTypes
+                };
+                var outboundInterceptorFactory = new OutboundInterceptorFactory(interceptorSetting);
+                var interceptors = outboundInterceptorFactory.CreateInterceptors(scope);
+                Assert.AreEqual(1, interceptors.Count());
+            }
+        }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/Nimbus.UnitTests.csproj
+++ b/src/Tests/Nimbus.UnitTests/Nimbus.UnitTests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="DispatcherTests\WhenInboundInterceptorThrowsExceptionOnRequestHandlerExecuting.cs" />
     <Compile Include="InfrastructureTests\Handlers\MyLongNamedHandler.cs" />
     <Compile Include="InfrastructureTests\MessageContracts\MyEventWithALongName.cs" />
+    <Compile Include="InterceptorTests\WhenBuildingABusWithAutofacAndInterceptors.cs" />
     <Compile Include="NullDependencyResolver.cs" />
     <Compile Include="NullDependencyResolverScope.cs" />
     <Compile Include="NullInboundInterceptorFactory.cs" />

--- a/src/Tests/Nimbus.UnitTests/NullDependencyResolverScope.cs
+++ b/src/Tests/Nimbus.UnitTests/NullDependencyResolverScope.cs
@@ -19,6 +19,11 @@ namespace Nimbus.UnitTests
             throw new NotImplementedException();
         }
 
+        public object Resolve(Type componentType)
+        {
+            throw new NotImplementedException();
+        }
+
         public object Resolve(Type componentType, string componentName)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Fixes NimbusAPI/Nimbus#103

Takes the approach of walking away from named registrations, to just types

Feels like I'm adding code, but I didn't want to run off and remove all the named resolutions without prior conversation, but I also didn't see the value in proliferating the named resolution further
