### PR TITLE
Multicast request handlers can now return a Task.FromResult<TResponse>(n...

### DIFF
--- a/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
+++ b/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Tests\LargeMessageTests\WhenPushingAndPullingDataFromAzureBlobStorage.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\MessageContracts\BlackBallRequest.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\MessageContracts\BlackBallResponse.cs" />
+    <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\ApatheticBlackBallRequestHandler.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\GrumpyBlackBallRequestHandler.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\HappyBlackBallRequestHandler.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\SlowBlackBallRequestHandler.cs" />

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/ApatheticBlackBallRequestHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/ApatheticBlackBallRequestHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Nimbus.Handlers;
+using Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.RequestHandlers
+{
+    public class ApatheticBlackBallRequestHandler : IHandleMulticastRequest<BlackBallRequest, BlackBallResponse>
+    {
+        public Task<BlackBallResponse> Handle(BlackBallRequest request)
+        {
+            MethodCallCounter.RecordCall<ApatheticBlackBallRequestHandler>(handler => handler.Handle(request));
+
+            return Task.FromResult<BlackBallResponse>(null);
+        }
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/GrumpyBlackBallRequestHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/GrumpyBlackBallRequestHandler.cs
@@ -8,6 +8,8 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.RequestHan
     {
         public async Task<BlackBallResponse> Handle(BlackBallRequest request)
         {
+            MethodCallCounter.RecordCall<GrumpyBlackBallRequestHandler>(handler => handler.Handle(request));
+
             return new BlackBallResponse
                    {
                        IsBlackBalled = true,

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/HappyBlackBallRequestHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/HappyBlackBallRequestHandler.cs
@@ -8,6 +8,8 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.RequestHan
     {
         public async Task<BlackBallResponse> Handle(BlackBallRequest request)
         {
+            MethodCallCounter.RecordCall<HappyBlackBallRequestHandler>(handler => handler.Handle(request));
+
             return new BlackBallResponse
                    {
                        IsBlackBalled = false,

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/SlowBlackBallRequestHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/RequestHandlers/SlowBlackBallRequestHandler.cs
@@ -9,6 +9,8 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.RequestHan
     {
         public async Task<BlackBallResponse> Handle(BlackBallRequest request)
         {
+            MethodCallCounter.RecordCall<SlowBlackBallRequestHandler>(handler => handler.Handle(request));
+
             await Task.Delay(TimeSpan.FromSeconds(3));
 
             return new BlackBallResponse

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/WhenSendingAMulticastRequestThatShouldAllowAllResponders.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/WhenSendingAMulticastRequestThatShouldAllowAllResponders.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.MessageContracts;
@@ -11,7 +10,7 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests
     [TestFixture]
     public class WhenSendingAMulticastRequestThatShouldAllowAllResponders : TestForBus
     {
-        private IEnumerable<BlackBallResponse> _response;
+        private BlackBallResponse[] _response;
 
         protected override async Task When()
         {
@@ -20,13 +19,19 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests
                               ProspectiveMemberName = "Fred Flintstone",
                           };
 
-            _response = await Bus.MulticastRequest(request, TimeSpan.FromSeconds(6));
+            _response = (await Bus.MulticastRequest(request, TimeSpan.FromSeconds(6))).ToArray();
         }
 
         [Test]
         public async Task WeShouldReceiveThreeResponses()
         {
             _response.Count().ShouldBe(3);
+        }
+
+        [Test]
+        public async Task AllHandlersShouldHaveAtLeastReceivedTheRequest()
+        {
+            MethodCallCounter.AllReceivedMessages.OfType<BlackBallRequest>().Count().ShouldBe(4);
         }
     }
 }

--- a/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/WhenSendingAMulticastRequestThatShouldAllowTwoResponders.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/MulticastRequestResponseTests/WhenSendingAMulticastRequestThatShouldAllowTwoResponders.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests.MessageContracts;
@@ -11,7 +10,7 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests
     [TestFixture]
     public class WhenSendingAMulticastRequestThatShouldAllowTwoResponders : TestForBus
     {
-        private IEnumerable<BlackBallResponse> _response;
+        private BlackBallResponse[] _response;
 
         protected override async Task When()
         {
@@ -20,13 +19,19 @@ namespace Nimbus.IntegrationTests.Tests.MulticastRequestResponseTests
                               ProspectiveMemberName = "Fred Flintstone",
                           };
 
-            _response = await Bus.MulticastRequest(request, TimeSpan.FromSeconds(3));
+            _response = (await Bus.MulticastRequest(request, TimeSpan.FromSeconds(3))).ToArray();
         }
 
         [Test]
         public async Task WeShouldReceiveTwoResponses()
         {
             _response.Count().ShouldBe(2);
+        }
+
+        [Test]
+        public async Task AllHandlersShouldHaveAtLeastReceivedTheRequest()
+        {
+            MethodCallCounter.AllReceivedMessages.OfType<BlackBallRequest>().Count().ShouldBe(4);
         }
     }
 }


### PR DESCRIPTION
...ull) to decline to reply to a request. (Foxes #110).
