### PR TITLE
No longer using CorrelationId for request/response. We have a custom mes...

### DIFF
--- a/src/Nimbus/Extensions/BrokeredMessageExtensions.cs
+++ b/src/Nimbus/Extensions/BrokeredMessageExtensions.cs
@@ -24,6 +24,11 @@ namespace Nimbus.Extensions
             return message;
         }
 
+        internal static BrokeredMessage WithReplyToRequestId(this BrokeredMessage message, string requestId)
+        {
+            return message.WithProperty(MessagePropertyKeys.InReplyToRequestId, requestId);
+        }
+
         internal static BrokeredMessage WithReplyTo(this BrokeredMessage message, string replyTo)
         {
             message.ReplyTo = replyTo;

--- a/src/Nimbus/Infrastructure/BrokeredMessageServices/BrokeredMessageFactory.cs
+++ b/src/Nimbus/Infrastructure/BrokeredMessageServices/BrokeredMessageFactory.cs
@@ -115,7 +115,7 @@ namespace Nimbus.Infrastructure.BrokeredMessageServices
 
             return Task.Run(async () =>
                                   {
-                                      var responseMessage = (await Create(responseContent)).WithCorrelationId(originalRequest.CorrelationId);
+                                      var responseMessage = (await Create(responseContent)).WithReplyToRequestId(originalRequest.MessageId);
                                       responseMessage.Properties[MessagePropertyKeys.RequestSuccessful] = true;
 
                                       return responseMessage;
@@ -128,7 +128,7 @@ namespace Nimbus.Infrastructure.BrokeredMessageServices
 
             return Task.Run(async () =>
                                   {
-                                      var responseMessage = (await Create()).WithCorrelationId(originalRequest.CorrelationId);
+                                      var responseMessage = (await Create()).WithReplyToRequestId(originalRequest.MessageId);
                                       responseMessage.Properties[MessagePropertyKeys.RequestSuccessful] = false;
                                       foreach (var prop in exception.ExceptionDetailsAsProperties(_clock.UtcNow)) responseMessage.Properties.Add(prop.Key, prop.Value);
 

--- a/src/Nimbus/Infrastructure/MessagePropertyKeys.cs
+++ b/src/Nimbus/Infrastructure/MessagePropertyKeys.cs
@@ -12,5 +12,6 @@
         public const string ExceptionIdentityName = "ExceptionIdentityName";
         public const string LargeBodyBlobIdentifier = "LargeBodyBlobIdentifier";
         public const string MessageType = "MessageType";
+        public const string InReplyToRequestId = "InReplyToRequestId";
     }
 }

--- a/src/Nimbus/Infrastructure/RequestResponse/ResponseMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/ResponseMessageDispatcher.cs
@@ -17,8 +17,8 @@ namespace Nimbus.Infrastructure.RequestResponse
 
         public async Task Dispatch(BrokeredMessage message)
         {
-            var correlationId = Guid.Parse(message.CorrelationId);
-            var responseCorrelationWrapper = _requestResponseCorrelator.TryGetWrapper(correlationId);
+            var requestId = Guid.Parse((string)message.Properties[MessagePropertyKeys.InReplyToRequestId]);
+            var responseCorrelationWrapper = _requestResponseCorrelator.TryGetWrapper(requestId);
             if (responseCorrelationWrapper == null) return;
 
             var success = (bool) message.Properties[MessagePropertyKeys.RequestSuccessful];


### PR DESCRIPTION
...sage property now.
