### PR TITLE
Logging for LongRunningTasks + Integration Tests

### DIFF
--- a/src/Nimbus/Infrastructure/Commands/CommandMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/Commands/CommandMessageDispatcher.cs
@@ -73,7 +73,7 @@ namespace Nimbus.Infrastructure.Commands
                     }
 
                     var handlerTask = handler.Handle(busCommand);
-                    var wrapper = new LongLivedTaskWrapper(handlerTask, handler as ILongRunningTask, message, _clock);
+                    var wrapper = new LongLivedTaskWrapper(_logger, handlerTask, handler as ILongRunningTask, message, _clock);
                     await wrapper.AwaitCompletion();
 
                     foreach (var interceptor in interceptors.Reverse())

--- a/src/Nimbus/Infrastructure/Events/EventMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/Events/EventMessageDispatcher.cs
@@ -77,7 +77,7 @@ namespace Nimbus.Infrastructure.Events
                     }
 
                     var handlerTask = DispatchToHandleMethod(busEvent, handler);
-                    var wrapper = new LongLivedTaskWrapper(handlerTask, handler as ILongRunningTask, message, _clock);
+                    var wrapper = new LongLivedTaskWrapper(_logger, handlerTask, handler as ILongRunningTask, message, _clock);
                     await wrapper.AwaitCompletion();
 
                     foreach (var interceptor in interceptors.Reverse())

--- a/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
+++ b/src/Nimbus/Infrastructure/LongLivedTaskWrapperBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
+using Nimbus.Extensions;
 using Nimbus.Handlers;
 using Nimbus.MessageContracts.Exceptions;
 
@@ -10,8 +11,8 @@ namespace Nimbus.Infrastructure
 {
     internal class LongLivedTaskWrapper<T> : LongLivedTaskWrapperBase
     {
-        public LongLivedTaskWrapper(Task<T> handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
-            : base(handlerTask, longRunningHandler, message, clock)
+        public LongLivedTaskWrapper(ILogger logger, Task<T> handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
+            : base(logger, handlerTask, longRunningHandler, message, clock)
         {
         }
 
@@ -24,8 +25,8 @@ namespace Nimbus.Infrastructure
 
     internal class LongLivedTaskWrapper : LongLivedTaskWrapperBase
     {
-        public LongLivedTaskWrapper(Task handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
-            : base(handlerTask, longRunningHandler, message, clock)
+        public LongLivedTaskWrapper(ILogger logger, Task handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
+            : base(logger, handlerTask, longRunningHandler, message, clock)
         {
         }
 
@@ -38,6 +39,7 @@ namespace Nimbus.Infrastructure
 
     internal abstract class LongLivedTaskWrapperBase
     {
+        private readonly ILogger _logger;
         protected readonly Task HandlerTask;
         private readonly ILongRunningTask _longRunningHandler;
         private readonly BrokeredMessage _message;
@@ -49,14 +51,35 @@ namespace Nimbus.Infrastructure
         // BrokeredMessage is sealed and can't easily be mocked so we sub our our
         // invocation strategies for its properties/methods instead.  -andrewh 12/3/2014
         internal static Func<BrokeredMessage, DateTimeOffset> LockedUntilUtcStrategy = m => m.LockedUntilUtc;
-        internal static Action<BrokeredMessage> RenewLockStrategy = m => m.RenewLock();
+        internal static Action<BrokeredMessage> RenewLockStrategy;
 
-        protected LongLivedTaskWrapperBase(Task handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
+        protected LongLivedTaskWrapperBase(ILogger logger, Task handlerTask, ILongRunningTask longRunningHandler, BrokeredMessage message, IClock clock)
         {
+            _logger = logger;
             HandlerTask = handlerTask;
             _longRunningHandler = longRunningHandler;
             _message = message;
             _clock = clock;
+
+            // Use the default method unless another has been defined for testing
+            if (RenewLockStrategy == null) RenewLockStrategy = RenewLock;
+        }
+
+        private void RenewLock(BrokeredMessage message)
+        {
+            // http://msdn.microsoft.com/en-us/library/microsoft.servicebus.messaging.brokeredmessage.renewlock.aspx
+            // RenewLock updates the message lock by resetting the service side timer, and updates the LockedUntilUtc property once RenewLock completes.
+            // You can renew locks for the same duration as the entity lock timeout, and there is no maximum duration for a lock renewal.
+            _logger.Debug("Renewing message lock for message [MessageType:{0}, MessageId:{1}, CorrelationId:{2}]",
+                          message.SafelyGetBodyTypeNameOrDefault(),
+                          message.MessageId,
+                          message.CorrelationId);
+            message.RenewLock();
+            _logger.Info("Renewed lock until {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]",
+                         message.LockedUntilUtc,
+                         message.SafelyGetBodyTypeNameOrDefault(),
+                         message.MessageId,
+                         message.CorrelationId);
         }
 
         protected async Task<Task> AwaitCompletionInternal(Task handlerTask)
@@ -75,6 +98,11 @@ namespace Nimbus.Infrastructure
 
             if (_longRunningHandler != null)
             {
+                _logger.Debug("Configuring watcher for long running handler {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]",
+                              _longRunningHandler.GetType().FullName,
+                              _message.SafelyGetBodyTypeNameOrDefault(),
+                              _message.MessageId,
+                              _message.CorrelationId);
                 var watcherTask = Watch(_longRunningHandler, _message);
                 tasks.Add(watcherTask);
             }
@@ -91,6 +119,12 @@ namespace Nimbus.Infrastructure
 
         private async Task Watch(ILongRunningTask longRunningHandler, BrokeredMessage message)
         {
+            _logger.Debug("Starting to watch long running handler {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]",
+              _longRunningHandler.GetType().FullName,
+              _message.SafelyGetBodyTypeNameOrDefault(),
+              _message.MessageId,
+              _message.CorrelationId);
+
             while (true)
             {
                 var lockedUntil = LockedUntilUtcStrategy(message);
@@ -99,11 +133,37 @@ namespace Nimbus.Infrastructure
                 var timeToDelay = halfOfRemainingLockTime > TimeSpan.Zero ? halfOfRemainingLockTime : TimeSpan.Zero;
                 await Task.Delay(timeToDelay);
 
-                if (_completed) return;
+                if (_completed)
+                {
+                    _logger.Debug("Long running handler has completed {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]",
+                                  _longRunningHandler.GetType().FullName,
+                                  _message.SafelyGetBodyTypeNameOrDefault(),
+                                  _message.MessageId,
+                                  _message.CorrelationId);
+                    return;
+                }
                 lock (_mutex)
                 {
-                    if (_completed) return;
-                    if (!longRunningHandler.IsAlive) throw new BusException("Long-running handler died or stopped responding.");
+                    if (_completed)
+                    {
+                        _logger.Debug("Long running handler has completed {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]",
+                                      _longRunningHandler.GetType().FullName,
+                                      _message.SafelyGetBodyTypeNameOrDefault(),
+                                      _message.MessageId,
+                                      _message.CorrelationId);
+                        return;
+                    }
+
+                    if (!longRunningHandler.IsAlive)
+                    {
+                        throw new BusException(
+                            "Long running handler is reporting that it is no longer alive! {0} for message [MessageType:{1}, MessageId:{2}, CorrelationId:{3}]"
+                                .FormatWith(_longRunningHandler.GetType().FullName,
+                                            _message.SafelyGetBodyTypeNameOrDefault(),
+                                            _message.MessageId,
+                                            _message.CorrelationId));
+                    }
+
                     RenewLockStrategy(message);
                 }
             }

--- a/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessageDispatcher.cs
@@ -86,7 +86,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                 try
                 {
                     var handlerTask = handler.Handle(busRequest);
-                    var wrapperTask = new LongLivedTaskWrapper<TBusResponse>(handlerTask, handler as ILongRunningTask, message, _clock);
+                    var wrapperTask = new LongLivedTaskWrapper<TBusResponse>(_logger, handlerTask, handler as ILongRunningTask, message, _clock);
                     var response = await wrapperTask.AwaitCompletion();
 
                     // ReSharper disable CompareNonConstrainedGenericWithNull

--- a/src/Nimbus/Infrastructure/RequestResponse/RequestMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/RequestMessageDispatcher.cs
@@ -87,7 +87,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                     }
 
                     var handlerTask = handler.Handle(busRequest);
-                    var wrapperTask = new LongLivedTaskWrapper<TBusResponse>(handlerTask, handler as ILongRunningTask, message, _clock);
+                    var wrapperTask = new LongLivedTaskWrapper<TBusResponse>(_logger, handlerTask, handler as ILongRunningTask, message, _clock);
                     var response = await wrapperTask.AwaitCompletion();
 
                     var responseMessage = (await _brokeredMessageFactory.CreateSuccessfulResponse(response, message))

--- a/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
+++ b/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
@@ -127,6 +127,8 @@
     <Compile Include="Tests\LargeMessageTests\WhenSendingALargeRequestUsingDiskStorage.cs" />
     <Compile Include="Tests\LargeMessageTests\WhenCreatingALargeMessageUsingTheUnsupportedMessageBodyStore.cs" />
     <Compile Include="Tests\LargeMessageTests\WhenPushingAndPullingDataFromAzureBlobStorage.cs" />
+    <Compile Include="Tests\LongRunningHandlerTests\CommandHandlers\LongRunningEventHandler.cs" />
+    <Compile Include="Tests\LongRunningHandlerTests\MessageContracts\LongRunningCommandCompletedEvent.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\MessageContracts\BlackBallRequest.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\MessageContracts\BlackBallResponse.cs" />
     <Compile Include="Tests\MulticastRequestResponseTests\RequestHandlers\ApatheticBlackBallRequestHandler.cs" />
@@ -142,6 +144,9 @@
     <Compile Include="Tests\SimpleDispatchContextCorrelationTests\MessageContracts\FirstCommand.cs" />
     <Compile Include="Tests\SimpleDispatchContextCorrelationTests\MessageContracts\SecondCommand.cs" />
     <Compile Include="Tests\SimpleDispatchContextCorrelationTests\WhenDispatchingACommandOnTheBusAndSendingASecondCommand.cs" />
+    <Compile Include="Tests\LongRunningHandlerTests\CommandHandlers\LongRunningCommandHandler.cs" />
+    <Compile Include="Tests\LongRunningHandlerTests\MessageContracts\LongRunningCommand.cs" />
+    <Compile Include="Tests\LongRunningHandlerTests\WhenHandlingALongRunningCommandOnTheBus.cs" />
     <Compile Include="Tests\SimpleCommandSendingTests\MessageContracts\SomeCommandThatHasNoHandler.cs" />
     <Compile Include="Tests\SimpleCommandSendingTests\WhenSendingACommandThatHasNoHandler.cs" />
     <Compile Include="Tests\SimplePubSubTests\MessageContracts\SomeEventWeDoNotHandle.cs" />

--- a/src/Tests/Nimbus.IntegrationTests/TestHarnessBusFactory.cs
+++ b/src/Tests/Nimbus.IntegrationTests/TestHarnessBusFactory.cs
@@ -36,6 +36,7 @@ namespace Nimbus.IntegrationTests
                                       .WithGlobalOutboundInterceptorTypes(typeProvider.InterceptorTypes.Where(t => typeof(IOutboundInterceptor).IsAssignableFrom(t)).ToArray())
                                       .WithDependencyResolver(new DependencyResolver(typeProvider))
                                       .WithDefaultTimeout(TimeSpan.FromSeconds(10))
+                                      .WithDefaultMessageLockDuration(TimeSpan.FromSeconds(10))
                                       .WithLogger(logger)
                                       .WithDebugOptions(
                                           dc =>

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/CommandHandlers/LongRunningCommandHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/CommandHandlers/LongRunningCommandHandler.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nimbus.Handlers;
+using Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.MessageContracts;
+using Nimbus.Tests.Common;
+
+namespace Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.CommandHandlers
+{
+    public class LongRunningCommandHandler : IHandleCommand<LongRunningCommand>, ILongRunningTask
+    {
+        internal static IBus Bus { get; set; }
+
+        public async Task Handle(LongRunningCommand busCommand)
+        {
+            Console.WriteLine("Received LongRunningCommand @ {0}", DateTime.Now);
+            MethodCallCounter.RecordCall<LongRunningCommandHandler>(ch => ch.Handle(busCommand));
+
+            // This should cause the lock to be renewed a few times
+            await Task.Delay(TimeSpan.FromSeconds(18));
+
+            Console.WriteLine("Publishing LongRunningCommandCompletedEvent @ {0}", DateTime.Now);
+            await Bus.Publish(new LongRunningCommandCompletedEvent());
+        }
+
+        public bool IsAlive
+        {
+            get
+            {
+                Console.WriteLine("Asked if LongRunningCommandHandler was still alive: Of course we are! @ {0}", DateTime.Now);
+                return true;
+            }
+        }
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/CommandHandlers/LongRunningEventHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/CommandHandlers/LongRunningEventHandler.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nimbus.Handlers;
+using Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.MessageContracts;
+using Nimbus.Tests.Common;
+
+namespace Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.CommandHandlers
+{
+    public class LongRunningEventHandler : IHandleCompetingEvent<LongRunningCommandCompletedEvent>
+    {
+        public async Task Handle(LongRunningCommandCompletedEvent busEvent)
+        {
+            Console.WriteLine("Received LongRunningCommandCompletedEvent @ {0}", DateTime.Now);
+            MethodCallCounter.RecordCall<LongRunningEventHandler>(ch => ch.Handle(busEvent));
+        }
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/MessageContracts/LongRunningCommand.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/MessageContracts/LongRunningCommand.cs
@@ -1,0 +1,8 @@
+﻿using Nimbus.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.MessageContracts
+{
+    public class LongRunningCommand : IBusCommand
+    {
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/MessageContracts/LongRunningCommandCompletedEvent.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/MessageContracts/LongRunningCommandCompletedEvent.cs
@@ -1,0 +1,8 @@
+using Nimbus.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.MessageContracts
+{
+    public class LongRunningCommandCompletedEvent : IBusEvent
+    {
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/WhenHandlingALongRunningCommandOnTheBus.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LongRunningHandlerTests/WhenHandlingALongRunningCommandOnTheBus.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.CommandHandlers;
+using Nimbus.IntegrationTests.Tests.LongRunningHandlerTests.MessageContracts;
+using Nimbus.Tests.Common;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.IntegrationTests.Tests.LongRunningHandlerTests
+{
+    [TestFixture]
+    [Timeout(60*1000)]
+    public class WhenHandlingALongRunningCommandOnTheBus : TestForBus
+    {
+        protected override async Task When()
+        {
+            // NOTE: This test assumes the DefaultMessageLockDuration is 10secs
+            LongRunningCommandHandler.Bus = Bus;
+
+            var someCommand = new LongRunningCommand();
+            Console.WriteLine("Sending LongRunningCommand @ {0}", DateTime.Now);
+            await Bus.Send(someCommand);
+            await TimeSpan.FromMinutes(1.5).WaitUntil(() => MethodCallCounter.AllReceivedMessages.Count() == 2);
+            Console.WriteLine("Completing test @ {0}", DateTime.Now);
+        }
+
+        [Test]
+        public async Task TheCommandHandlerShouldReceiveThatCommandAndStartProcessing()
+        {
+            MethodCallCounter.AllReceivedMessages.OfType<LongRunningCommand>().Count().ShouldBe(1);
+        }
+        
+        [Test]
+        public async Task TheCommandHandlerShouldGetCalledOnce()
+        {
+            var calls = MethodCallCounter.ReceivedCallsWithAnyArg<LongRunningCommandHandler>(h => h.Handle(null));
+            calls.Count().ShouldBe(1);
+        }
+
+        [Test]
+        public async Task TheEventHandlerShouldHaveBeenNotifiedTheLongRunningTaskSucceeded()
+        {
+            MethodCallCounter.AllReceivedMessages.OfType<LongRunningCommandCompletedEvent>().Count().ShouldBe(1);
+        }
+
+        [Test]
+        public async Task TheEventHandlerShouldGetCalledOnce()
+        {
+            var calls = MethodCallCounter.ReceivedCallsWithAnyArg<LongRunningEventHandler>(h => h.Handle(null));
+            calls.Count().ShouldBe(1);
+        }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingACommandToALongRunningHandler.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingACommandToALongRunningHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.ServiceBus.Messaging;
 using Nimbus.Infrastructure;
 using Nimbus.UnitTests.DispatcherTests.Handlers;
 using Nimbus.UnitTests.DispatcherTests.MessageContracts;
+using NSubstitute;
 using NUnit.Framework;
 using Shouldly;
 
@@ -40,7 +41,7 @@ namespace Nimbus.UnitTests.DispatcherTests
             LongLivedTaskWrapperBase.LockedUntilUtcStrategy = m => _lockedUntil;
 
             _lockedUntil = DateTimeOffset.UtcNow.AddSeconds(1);
-            return new LongLivedTaskWrapper(_handlerTask, _handler, _brokeredMessage, _clock);
+            return new LongLivedTaskWrapper(Substitute.For<ILogger>(), _handlerTask, _handler, _brokeredMessage, _clock);
         }
 
         protected override async Task When()


### PR DESCRIPTION
We've been finding a lot of `MessageLockLostExceptions` in our error logs. The logging is a bit sparse around the `LongLivedTaskWrapper` and this commit seeks to provide the diagnostics required to better understand why these exceptions are being thrown.

There are two primary cases we're hunting down:
1. The Message isn't even Dispatched to the Handler before the MessageLock expires, so it's dead in the water before the dispatch task is even started.
2. The Message is Dispatched in time, but the `LongLivedTaskWrapper` watcher task isn't running so it never renews the MessageLock.

The smoking gun looks like ThreadPool starvation under high load conditions.
