### PR TITLE
Change so that if we request a batch size of 0 we return an empty array ...

### DIFF
--- a/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusQueueMessageReceiver.cs
+++ b/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusQueueMessageReceiver.cs
@@ -33,6 +33,9 @@ namespace Nimbus.Infrastructure.MessageSendersAndReceivers
 
         protected override async Task<BrokeredMessage[]> FetchBatch(int batchSize, Task cancellationTask)
         {
+            if (batchSize < 1)
+                return new BrokeredMessage[0];
+
             try
             {
                 var messageReceiver = await GetMessageReceiver();

--- a/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusSubscriptionMessageReceiver.cs
+++ b/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusSubscriptionMessageReceiver.cs
@@ -38,6 +38,9 @@ namespace Nimbus.Infrastructure.MessageSendersAndReceivers
 
         protected override async Task<BrokeredMessage[]> FetchBatch(int batchSize, Task cancellationTask)
         {
+            if (batchSize < 1)
+                return new BrokeredMessage[0];
+
             try
             {
                 var subscriptionClient = await GetSubscriptionClient();


### PR DESCRIPTION
...instead of attempting to retrieve messages from the SB

This was noticed with thread pool starvation and was showing up quite often in our error logs, this reduced those errors for us.
