### PR TITLE
dont discard message receiver when we are stopping the receiver

### DIFF
--- a/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusQueueMessageReceiver.cs
+++ b/src/Nimbus/Infrastructure/MessageSendersAndReceivers/NimbusQueueMessageReceiver.cs
@@ -44,11 +44,8 @@ namespace Nimbus.Infrastructure.MessageSendersAndReceivers
                 await Task.WhenAny(receiveTask, cancellationTask);
 
                 if (cancellationTask.IsCompleted)
-                {
-                    DiscardMessageReceiver();
                     return new BrokeredMessage[0];
-                }
-
+                
                 var messages = await receiveTask;
                 return messages.ToArray();
             }


### PR DESCRIPTION
This causes issues when you try and Stop() the bus when there is long running work left, when the task completes the message client has already been disposed and the message is unable to be completed.

By removing the discard the message can successfully be completed before the bus stops.
