### PR TITLE
TTL and Autodelete knobs

### DIFF
--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -33,6 +33,9 @@ namespace Nimbus.Configuration
         internal DefaultTimeoutSetting DefaultTimeout { get; set; }
         internal DefaultMessageLockDurationSetting DefaultMessageLockDuration { get; set; }
         internal MaxDeliveryAttemptSetting MaxDeliveryAttempts { get; set; }
+        internal SubscriptionDefaultMessageTimeToLiveSetting SubscriptionDefaultMessageTimeToLive { get; set; }
+        internal SubscriptionAutoDeleteOnIdleSetting SubscriptionAutoDeleteOnIdle { get; set; }
+        internal EnableDeadLetteringOnMessageExpirationSetting EnableDeadLetteringOnMessageExpiration { get; set; }
         internal HeartbeatIntervalSetting HeartbeatInterval { get; set; }
         internal GlobalInboundInterceptorTypesSetting GlobalInboundInterceptorTypes { get; set; }
         internal GlobalOutboundInterceptorTypesSetting GlobalOutboundInterceptorTypes { get; set; }

--- a/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
@@ -107,6 +107,24 @@ namespace Nimbus.Configuration
             return configuration;
         }
 
+        public static BusBuilderConfiguration WithSubscriptionDefaultMessageTimeToLive(this BusBuilderConfiguration configuration, TimeSpan timeToLive)
+        {
+            configuration.SubscriptionDefaultMessageTimeToLive = new SubscriptionDefaultMessageTimeToLiveSetting { Value = timeToLive };
+            return configuration;
+        }
+
+        public static BusBuilderConfiguration WithSubscriptionAutoDeleteOnIdle(this BusBuilderConfiguration configuration, TimeSpan autoDeleteOnIdle)
+        {
+            configuration.SubscriptionAutoDeleteOnIdle = new SubscriptionAutoDeleteOnIdleSetting { Value = autoDeleteOnIdle };
+            return configuration;
+        }
+
+        public static BusBuilderConfiguration WithEnableDeadLetteringOnMessageExpiration(this BusBuilderConfiguration configuration, bool enableDeadLettering)
+        {
+            configuration.EnableDeadLetteringOnMessageExpiration = new EnableDeadLetteringOnMessageExpirationSetting { Value = enableDeadLettering };
+            return configuration;
+        }
+
         public static BusBuilderConfiguration WithHeartbeatInterval(this BusBuilderConfiguration configuration, TimeSpan heartbeatInterval)
         {
             configuration.HeartbeatInterval = new HeartbeatIntervalSetting { Value = heartbeatInterval };

--- a/src/Nimbus/Configuration/Settings/EnableDeadLetteringOnMessageExpirationSetting.cs
+++ b/src/Nimbus/Configuration/Settings/EnableDeadLetteringOnMessageExpirationSetting.cs
@@ -1,0 +1,10 @@
+namespace Nimbus.Configuration.Settings
+{
+    public class EnableDeadLetteringOnMessageExpirationSetting : Setting<bool>
+    {
+        public override bool Default
+        {
+            get { return true; }
+        }
+    }
+}

--- a/src/Nimbus/Configuration/Settings/SubscriptionAutoDeleteOnIdleSetting.cs
+++ b/src/Nimbus/Configuration/Settings/SubscriptionAutoDeleteOnIdleSetting.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Nimbus.Configuration.Settings
+{
+    public class SubscriptionAutoDeleteOnIdleSetting : Setting<TimeSpan>
+    {
+        public override TimeSpan Default
+        {
+            get { return TimeSpan.FromDays(367); }
+        }
+
+        public override IEnumerable<string> Validate()
+        {
+            if (Value < TimeSpan.FromMinutes(5)) yield return "The minimum duration is 5 minutes.";
+        }
+    }
+}

--- a/src/Nimbus/Configuration/Settings/SubscriptionDefaultMessageTimeToLiveSetting.cs
+++ b/src/Nimbus/Configuration/Settings/SubscriptionDefaultMessageTimeToLiveSetting.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Nimbus.Configuration.Settings
+{
+    public class SubscriptionDefaultMessageTimeToLiveSetting : Setting<TimeSpan>
+    {
+        public override TimeSpan Default
+        {
+            get { return TimeSpan.MaxValue; }
+        }
+    }
+}

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -78,10 +78,13 @@
     <Compile Include="Configuration\Settings\DefaultMessageLockDurationSetting.cs" />
     <Compile Include="Configuration\LargeMessages\Settings\MaxLargeMessageSizeSetting.cs" />
     <Compile Include="Configuration\LargeMessages\Settings\MaxSmallMessageSizeSetting.cs" />
+    <Compile Include="Configuration\Settings\EnableDeadLetteringOnMessageExpirationSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalInboundInterceptorTypesSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalOutboundInterceptorTypesSetting.cs" />
     <Compile Include="Configuration\Settings\HeartbeatInterval.cs" />
     <Compile Include="Configuration\Settings\ServerConnectionCountSetting.cs" />
+    <Compile Include="Configuration\Settings\SubscriptionAutoDeleteOnIdleSetting.cs" />
+    <Compile Include="Configuration\Settings\SubscriptionDefaultMessageTimeToLiveSetting.cs" />
     <Compile Include="DelayedSendingExtensions.cs" />
     <Compile Include="Exceptions\DispatchFailedException.cs" />
     <Compile Include="Extensions\HandlerMapExtensions.cs" />


### PR DESCRIPTION
Added settings to allow the configuration of expiration of messages and deletion of subscriptions.The TTL and autodelete setting is per subscription (not topic) so that different clients can have different rules (in our case one of the clients is only interested in receiving recent events and is happy to drop older messages) 
