### PR TITLE
Path Generation

### DIFF
--- a/src/Nimbus.InfrastructureContracts/Nimbus.InfrastructureContracts.csproj
+++ b/src/Nimbus.InfrastructureContracts/Nimbus.InfrastructureContracts.csproj
@@ -66,6 +66,7 @@
     <Compile Include="IDispatchContext.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="ILargeMessageBodyStore.cs" />
+    <Compile Include="Routing\IPathFactory.cs" />
     <Compile Include="PropertyInjection\IRequireMessageProperties.cs" />
     <Compile Include="PropertyInjection\IRequireBrokeredMessage.cs" />
     <Compile Include="PropertyInjection\IRequireBus.cs" />

--- a/src/Nimbus.InfrastructureContracts/Nimbus.InfrastructureContracts.csproj
+++ b/src/Nimbus.InfrastructureContracts/Nimbus.InfrastructureContracts.csproj
@@ -66,7 +66,7 @@
     <Compile Include="IDispatchContext.cs" />
     <Compile Include="ILogger.cs" />
     <Compile Include="ILargeMessageBodyStore.cs" />
-    <Compile Include="Routing\IPathFactory.cs" />
+    <Compile Include="Routing\IPathGenerator.cs" />
     <Compile Include="PropertyInjection\IRequireMessageProperties.cs" />
     <Compile Include="PropertyInjection\IRequireBrokeredMessage.cs" />
     <Compile Include="PropertyInjection\IRequireBus.cs" />

--- a/src/Nimbus.InfrastructureContracts/Routing/IPathFactory.cs
+++ b/src/Nimbus.InfrastructureContracts/Routing/IPathFactory.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Nimbus.Routing
+{
+    public interface IPathFactory
+    {
+        string InputQueuePathFor(string applicationName, string instanceName);
+        string QueuePathFor(Type type);
+        string TopicPathFor(Type type);
+        string SubscriptionNameFor(string applicationName);
+        string SubscriptionNameFor(string applicationName, string instanceName);
+        string SubscriptionNameFor(string applicationName, Type handlerType);
+        string SubscriptionNameFor(string applicationName, string instanceName, Type handlerType);
+    }
+}

--- a/src/Nimbus.InfrastructureContracts/Routing/IPathGenerator.cs
+++ b/src/Nimbus.InfrastructureContracts/Routing/IPathGenerator.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Nimbus.Routing
 {
-    public interface IPathFactory
+    public interface IPathGenerator
     {
         string InputQueuePathFor(string applicationName, string instanceName);
         string QueuePathFor(Type type);

--- a/src/Nimbus.InfrastructureContracts/Routing/IRouter.cs
+++ b/src/Nimbus.InfrastructureContracts/Routing/IRouter.cs
@@ -4,6 +4,6 @@ namespace Nimbus.Routing
 {
     public interface IRouter
     {
-        string Route(Type messageType, QueueOrTopic queueOrTopic);
+        string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory);
     }
 }

--- a/src/Nimbus.InfrastructureContracts/Routing/IRouter.cs
+++ b/src/Nimbus.InfrastructureContracts/Routing/IRouter.cs
@@ -4,6 +4,6 @@ namespace Nimbus.Routing
 {
     public interface IRouter
     {
-        string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory);
+        string Route(Type messageType, QueueOrTopic queueOrTopic, IPathGenerator pathGenerator);
     }
 }

--- a/src/Nimbus.sln
+++ b/src/Nimbus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nimbus", "Nimbus\Nimbus.csproj", "{1B793C01-E824-4449-B93D-277626B1791F}"
 EndProject
@@ -68,6 +68,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nimbus.StressTests", "Tests\Nimbus.StressTests\Nimbus.StressTests.csproj", "{5CAED275-3485-449A-9EFC-6127B9257D82}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nimbus.Ninject", "Extensions\Nimbus.Ninject\Nimbus.Ninject.csproj", "{9C0550B4-F516-45E4-9BE2-48B8B02BDB50}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PingPong.PathGenerator", "Samples\PingPong.PathFactory\PingPong.PathGenerator.csproj", "{8D396B69-2B57-4B23-AE89-7EA80302F1FB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -179,6 +181,10 @@ Global
 		{9C0550B4-F516-45E4-9BE2-48B8B02BDB50}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9C0550B4-F516-45E4-9BE2-48B8B02BDB50}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9C0550B4-F516-45E4-9BE2-48B8B02BDB50}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D396B69-2B57-4B23-AE89-7EA80302F1FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D396B69-2B57-4B23-AE89-7EA80302F1FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D396B69-2B57-4B23-AE89-7EA80302F1FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D396B69-2B57-4B23-AE89-7EA80302F1FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -208,5 +214,6 @@ Global
 		{14AA0204-59C2-488D-BF5E-205CCA59E99D} = {0942FED4-86C1-468A-85DE-98B88DF22384}
 		{5CAED275-3485-449A-9EFC-6127B9257D82} = {0942FED4-86C1-468A-85DE-98B88DF22384}
 		{9C0550B4-F516-45E4-9BE2-48B8B02BDB50} = {96EF7BBF-8E5A-4FCB-9C47-FC38DDB3A1C6}
+		{8D396B69-2B57-4B23-AE89-7EA80302F1FB} = {3A9D386C-12D5-4A21-9292-60C0C5B3A7C2}
 	EndGlobalSection
 EndGlobal

--- a/src/Nimbus.sln.DotSettings
+++ b/src/Nimbus.sln.DotSettings
@@ -23,4 +23,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/SeparateAppDomainPerAssembly/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -23,6 +23,7 @@ namespace Nimbus.Configuration
         internal ISerializer Serializer { get; set; }
         internal ICompressor Compressor { get; set; }
         internal IRouter Router { get; set; }
+        internal IPathFactory PathFactory { get; set; }
 
         internal BusBuilderDebuggingConfiguration Debugging { get; set; }
         internal LargeMessageStorageConfiguration LargeMessageStorageConfiguration { get; set; }
@@ -50,6 +51,7 @@ namespace Nimbus.Configuration
             Debugging = new BusBuilderDebuggingConfiguration();
             LargeMessageStorageConfiguration = new LargeMessageStorageConfiguration();
             Router = new DestinationPerMessageTypeRouter();
+            PathFactory = new PathFactory();
 
             Logger = new NullLogger();
             Compressor = new NullCompressor();
@@ -75,7 +77,7 @@ namespace Nimbus.Configuration
 
             if (TypeProvider != null)
             {
-                validatableComponents.Add(new TypeProviderValidator(TypeProvider));
+                validatableComponents.Add(new TypeProviderValidator(TypeProvider, PathFactory));
             }
 
             var validationErrors = validatableComponents

--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -23,7 +23,7 @@ namespace Nimbus.Configuration
         internal ISerializer Serializer { get; set; }
         internal ICompressor Compressor { get; set; }
         internal IRouter Router { get; set; }
-        internal IPathFactory PathFactory { get; set; }
+        internal IPathGenerator PathGenerator { get; set; }
 
         internal BusBuilderDebuggingConfiguration Debugging { get; set; }
         internal LargeMessageStorageConfiguration LargeMessageStorageConfiguration { get; set; }
@@ -51,7 +51,7 @@ namespace Nimbus.Configuration
             Debugging = new BusBuilderDebuggingConfiguration();
             LargeMessageStorageConfiguration = new LargeMessageStorageConfiguration();
             Router = new DestinationPerMessageTypeRouter();
-            PathFactory = new PathFactory();
+            PathGenerator = new PathGenerator();
 
             Logger = new NullLogger();
             Compressor = new NullCompressor();
@@ -77,7 +77,7 @@ namespace Nimbus.Configuration
 
             if (TypeProvider != null)
             {
-                validatableComponents.Add(new TypeProviderValidator(TypeProvider, PathFactory));
+                validatableComponents.Add(new TypeProviderValidator(PathGenerator, TypeProvider));
             }
 
             var validationErrors = validatableComponents

--- a/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
@@ -155,5 +155,12 @@ namespace Nimbus.Configuration
             debugConfiguration(configuration.Debugging);
             return configuration;
         }
+
+        public static BusBuilderConfiguration WithPathGenerator(this BusBuilderConfiguration configuration,
+                                                              IPathGenerator pathGenerator)
+        {
+            configuration.PathGenerator = pathGenerator;
+            return configuration;
+        }
     }
 }

--- a/src/Nimbus/Configuration/Settings/ReplyQueueNameSetting.cs
+++ b/src/Nimbus/Configuration/Settings/ReplyQueueNameSetting.cs
@@ -1,12 +1,15 @@
-﻿using Nimbus.Infrastructure;
+﻿using Nimbus.Routing;
 
 namespace Nimbus.Configuration.Settings
 {
     public class ReplyQueueNameSetting : Setting<string>
     {
-        public ReplyQueueNameSetting(ApplicationNameSetting applicationName, InstanceNameSetting instanceName)
+        public ReplyQueueNameSetting(
+            ApplicationNameSetting applicationName, 
+            InstanceNameSetting instanceName, 
+            IPathFactory pathFactory)
         {
-            Value = PathFactory.InputQueuePathFor(applicationName, instanceName);
+            Value = pathFactory.InputQueuePathFor(applicationName, instanceName);
         }
     }
 }

--- a/src/Nimbus/Configuration/Settings/ReplyQueueNameSetting.cs
+++ b/src/Nimbus/Configuration/Settings/ReplyQueueNameSetting.cs
@@ -7,9 +7,9 @@ namespace Nimbus.Configuration.Settings
         public ReplyQueueNameSetting(
             ApplicationNameSetting applicationName, 
             InstanceNameSetting instanceName, 
-            IPathFactory pathFactory)
+            IPathGenerator pathGenerator)
         {
-            Value = pathFactory.InputQueuePathFor(applicationName, instanceName);
+            Value = pathGenerator.InputQueuePathFor(applicationName, instanceName);
         }
     }
 }

--- a/src/Nimbus/Infrastructure/AzureQueueManager.cs
+++ b/src/Nimbus/Infrastructure/AzureQueueManager.cs
@@ -20,6 +20,7 @@ namespace Nimbus.Infrastructure
         private readonly DefaultMessageTimeToLiveSetting _defaultMessageTimeToLive;
         private readonly AutoDeleteOnIdleSetting _autoDeleteOnIdle;
         private readonly EnableDeadLetteringOnMessageExpirationSetting _enableDeadLetteringOnMessageExpiration;
+        private readonly IPathFactory _pathFactory;
         private readonly ILogger _logger;
         private readonly IRouter _router;
 
@@ -40,7 +41,8 @@ namespace Nimbus.Infrastructure
                                  ITypeProvider typeProvider,
                                  DefaultMessageTimeToLiveSetting defaultMessageTimeToLive,
                                  AutoDeleteOnIdleSetting autoDeleteOnIdle,
-                                 EnableDeadLetteringOnMessageExpirationSetting enableDeadLetteringOnMessageExpiration)
+                                 EnableDeadLetteringOnMessageExpirationSetting enableDeadLetteringOnMessageExpiration,
+                                 IPathFactory pathFactory)
         {
             _namespaceManager = namespaceManager;
             _messagingFactory = messagingFactory;
@@ -52,6 +54,7 @@ namespace Nimbus.Infrastructure
             _defaultMessageTimeToLive = defaultMessageTimeToLive;
             _autoDeleteOnIdle = autoDeleteOnIdle;
             _enableDeadLetteringOnMessageExpiration = enableDeadLetteringOnMessageExpiration;
+            _pathFactory = pathFactory;
 
             _knownTopics = new ThreadSafeLazy<ConcurrentBag<string>>(FetchExistingTopics);
             _knownSubscriptions = new ThreadSafeLazy<ConcurrentBag<string>>(FetchExistingSubscriptions);
@@ -151,7 +154,7 @@ namespace Nimbus.Infrastructure
 
         private bool WeHaveAHandler(string topicPath)
         {
-            var paths = _typeProvider.AllTypesHandledViaTopics().Select(PathFactory.TopicPathFor);
+            var paths = _typeProvider.AllTypesHandledViaTopics().Select(_pathFactory.TopicPathFor);
             return paths.Contains(topicPath);
         }
 
@@ -273,7 +276,7 @@ namespace Nimbus.Infrastructure
 
         private void EnsureQueueExists(Type commandType)
         {
-            var queuePath = _router.Route(commandType, QueueOrTopic.Queue);
+            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathFactory);
             EnsureQueueExists(queuePath);
         }
 
@@ -324,7 +327,7 @@ namespace Nimbus.Infrastructure
 
         private string GetDeadLetterQueueName(Type messageContractType)
         {
-            var queuePath = _router.Route(messageContractType, QueueOrTopic.Queue);
+            var queuePath = _router.Route(messageContractType, QueueOrTopic.Queue, _pathFactory);
             var deadLetterQueueName = QueueClient.FormatDeadLetterPath(queuePath);
             return deadLetterQueueName;
         }

--- a/src/Nimbus/Infrastructure/AzureQueueManager.cs
+++ b/src/Nimbus/Infrastructure/AzureQueueManager.cs
@@ -20,7 +20,7 @@ namespace Nimbus.Infrastructure
         private readonly DefaultMessageTimeToLiveSetting _defaultMessageTimeToLive;
         private readonly AutoDeleteOnIdleSetting _autoDeleteOnIdle;
         private readonly EnableDeadLetteringOnMessageExpirationSetting _enableDeadLetteringOnMessageExpiration;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly ILogger _logger;
         private readonly IRouter _router;
 
@@ -42,7 +42,7 @@ namespace Nimbus.Infrastructure
                                  DefaultMessageTimeToLiveSetting defaultMessageTimeToLive,
                                  AutoDeleteOnIdleSetting autoDeleteOnIdle,
                                  EnableDeadLetteringOnMessageExpirationSetting enableDeadLetteringOnMessageExpiration,
-                                 IPathFactory pathFactory)
+                                 IPathGenerator pathGenerator)
         {
             _namespaceManager = namespaceManager;
             _messagingFactory = messagingFactory;
@@ -54,7 +54,7 @@ namespace Nimbus.Infrastructure
             _defaultMessageTimeToLive = defaultMessageTimeToLive;
             _autoDeleteOnIdle = autoDeleteOnIdle;
             _enableDeadLetteringOnMessageExpiration = enableDeadLetteringOnMessageExpiration;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
 
             _knownTopics = new ThreadSafeLazy<ConcurrentBag<string>>(FetchExistingTopics);
             _knownSubscriptions = new ThreadSafeLazy<ConcurrentBag<string>>(FetchExistingSubscriptions);
@@ -154,7 +154,7 @@ namespace Nimbus.Infrastructure
 
         private bool WeHaveAHandler(string topicPath)
         {
-            var paths = _typeProvider.AllTypesHandledViaTopics().Select(_pathFactory.TopicPathFor);
+            var paths = _typeProvider.AllTypesHandledViaTopics().Select(_pathGenerator.TopicPathFor);
             return paths.Contains(topicPath);
         }
 
@@ -276,7 +276,7 @@ namespace Nimbus.Infrastructure
 
         private void EnsureQueueExists(Type commandType)
         {
-            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathFactory);
+            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathGenerator);
             EnsureQueueExists(queuePath);
         }
 
@@ -327,7 +327,7 @@ namespace Nimbus.Infrastructure
 
         private string GetDeadLetterQueueName(Type messageContractType)
         {
-            var queuePath = _router.Route(messageContractType, QueueOrTopic.Queue, _pathFactory);
+            var queuePath = _router.Route(messageContractType, QueueOrTopic.Queue, _pathGenerator);
             var deadLetterQueueName = QueueClient.FormatDeadLetterPath(queuePath);
             return deadLetterQueueName;
         }

--- a/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 using Nimbus.DependencyResolution;
 using Nimbus.Extensions;
-using Nimbus.Infrastructure.Dispatching;
 using Nimbus.Infrastructure.Logging;
 using Nimbus.Interceptors.Outbound;
 using Nimbus.MessageContracts;
@@ -19,7 +18,7 @@ namespace Nimbus.Infrastructure.Commands
         private readonly ILogger _logger;
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly IDependencyResolver _dependencyResolver;
         private readonly IOutboundInterceptorFactory _outboundInterceptorFactory;
 
@@ -29,15 +28,15 @@ namespace Nimbus.Infrastructure.Commands
                                 ILogger logger,
                                 INimbusMessagingFactory messagingFactory,
                                 IOutboundInterceptorFactory outboundInterceptorFactory,
-                                IRouter router,
-                                IPathFactory pathFactory)
+                                IPathGenerator pathGenerator,
+                                IRouter router)
         {
             _brokeredMessageFactory = brokeredMessageFactory;
             _knownMessageTypeVerifier = knownMessageTypeVerifier;
             _logger = logger;
             _messagingFactory = messagingFactory;
             _router = router;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
         }
@@ -64,7 +63,7 @@ namespace Nimbus.Infrastructure.Commands
 
         private async Task Deliver<TBusCommand>(TBusCommand busCommand, Type commandType, BrokeredMessage brokeredMessage) where TBusCommand : IBusCommand
         {
-            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathFactory);
+            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathGenerator);
             brokeredMessage.DestinedForQueue(queuePath);
 
             using (var scope = _dependencyResolver.CreateChildScope())

--- a/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
+++ b/src/Nimbus/Infrastructure/Commands/BusCommandSender.cs
@@ -19,6 +19,7 @@ namespace Nimbus.Infrastructure.Commands
         private readonly ILogger _logger;
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
+        private readonly IPathFactory _pathFactory;
         private readonly IDependencyResolver _dependencyResolver;
         private readonly IOutboundInterceptorFactory _outboundInterceptorFactory;
 
@@ -28,13 +29,15 @@ namespace Nimbus.Infrastructure.Commands
                                 ILogger logger,
                                 INimbusMessagingFactory messagingFactory,
                                 IOutboundInterceptorFactory outboundInterceptorFactory,
-                                IRouter router)
+                                IRouter router,
+                                IPathFactory pathFactory)
         {
             _brokeredMessageFactory = brokeredMessageFactory;
             _knownMessageTypeVerifier = knownMessageTypeVerifier;
             _logger = logger;
             _messagingFactory = messagingFactory;
             _router = router;
+            _pathFactory = pathFactory;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
         }
@@ -61,7 +64,7 @@ namespace Nimbus.Infrastructure.Commands
 
         private async Task Deliver<TBusCommand>(TBusCommand busCommand, Type commandType, BrokeredMessage brokeredMessage) where TBusCommand : IBusCommand
         {
-            var queuePath = _router.Route(commandType, QueueOrTopic.Queue);
+            var queuePath = _router.Route(commandType, QueueOrTopic.Queue, _pathFactory);
             brokeredMessage.DestinedForQueue(queuePath);
 
             using (var scope = _dependencyResolver.CreateChildScope())

--- a/src/Nimbus/Infrastructure/Commands/CommandMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Commands/CommandMessagePumpsFactory.cs
@@ -21,6 +21,7 @@ namespace Nimbus.Infrastructure.Commands
         private readonly INimbusTaskFactory _taskFactory;
         private readonly IRouter _router;
         private readonly ITypeProvider _typeProvider;
+        private readonly IPathFactory _pathFactory;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
 
@@ -32,7 +33,8 @@ namespace Nimbus.Infrastructure.Commands
                                           INimbusMessagingFactory messagingFactory,
                                           INimbusTaskFactory taskFactory,
                                           IRouter router,
-                                          ITypeProvider typeProvider)
+                                          ITypeProvider typeProvider,
+                                          IPathFactory pathFactory)
         {
             _clock = clock;
             _dispatchContextManager = dispatchContextManager;
@@ -42,6 +44,7 @@ namespace Nimbus.Infrastructure.Commands
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
+            _pathFactory = pathFactory;
             _taskFactory = taskFactory;
         }
 
@@ -53,7 +56,7 @@ namespace Nimbus.Infrastructure.Commands
             // Create a single connection to each command queue determined by routing
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue)})
+                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathFactory)})
                 .GroupBy(b => b.QueuePath)
                 .Select(g => new {QueuePath = g.Key, HandlerTypes = g.SelectMany(x => _handlerMapper.GetHandlerTypesFor(openGenericHandlerType, x.MessageType))});
 

--- a/src/Nimbus/Infrastructure/Commands/CommandMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Commands/CommandMessagePumpsFactory.cs
@@ -21,7 +21,7 @@ namespace Nimbus.Infrastructure.Commands
         private readonly INimbusTaskFactory _taskFactory;
         private readonly IRouter _router;
         private readonly ITypeProvider _typeProvider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
 
@@ -32,9 +32,9 @@ namespace Nimbus.Infrastructure.Commands
                                           IMessageDispatcherFactory messageDispatcherFactory,
                                           INimbusMessagingFactory messagingFactory,
                                           INimbusTaskFactory taskFactory,
+                                          IPathGenerator pathGenerator,
                                           IRouter router,
-                                          ITypeProvider typeProvider,
-                                          IPathFactory pathFactory)
+                                          ITypeProvider typeProvider)
         {
             _clock = clock;
             _dispatchContextManager = dispatchContextManager;
@@ -44,7 +44,7 @@ namespace Nimbus.Infrastructure.Commands
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _taskFactory = taskFactory;
         }
 
@@ -56,7 +56,7 @@ namespace Nimbus.Infrastructure.Commands
             // Create a single connection to each command queue determined by routing
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathFactory)})
+                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathGenerator)})
                 .GroupBy(b => b.QueuePath)
                 .Select(g => new {QueuePath = g.Key, HandlerTypes = g.SelectMany(x => _handlerMapper.GetHandlerTypesFor(openGenericHandlerType, x.MessageType))});
 

--- a/src/Nimbus/Infrastructure/Events/BusEventSender.cs
+++ b/src/Nimbus/Infrastructure/Events/BusEventSender.cs
@@ -13,6 +13,7 @@ namespace Nimbus.Infrastructure.Events
     {
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
+        private readonly IPathFactory _pathFactory;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly ILogger _logger;
         private readonly IKnownMessageTypeVerifier _knownMessageTypeVerifier;
@@ -25,10 +26,12 @@ namespace Nimbus.Infrastructure.Events
                               ILogger logger,
                               INimbusMessagingFactory messagingFactory,
                               IOutboundInterceptorFactory outboundInterceptorFactory,
-                              IRouter router)
+                              IRouter router,
+                              IPathFactory pathFactory)
         {
             _messagingFactory = messagingFactory;
             _router = router;
+            _pathFactory = pathFactory;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _brokeredMessageFactory = brokeredMessageFactory;
@@ -43,7 +46,7 @@ namespace Nimbus.Infrastructure.Events
             _knownMessageTypeVerifier.AssertValidMessageType(eventType);
 
             var brokeredMessage = await _brokeredMessageFactory.Create(busEvent);
-            var topicPath = _router.Route(eventType, QueueOrTopic.Topic);
+            var topicPath = _router.Route(eventType, QueueOrTopic.Topic, _pathFactory);
 
             using (var scope = _dependencyResolver.CreateChildScope())
             {

--- a/src/Nimbus/Infrastructure/Events/BusEventSender.cs
+++ b/src/Nimbus/Infrastructure/Events/BusEventSender.cs
@@ -13,7 +13,7 @@ namespace Nimbus.Infrastructure.Events
     {
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly ILogger _logger;
         private readonly IKnownMessageTypeVerifier _knownMessageTypeVerifier;
@@ -26,12 +26,12 @@ namespace Nimbus.Infrastructure.Events
                               ILogger logger,
                               INimbusMessagingFactory messagingFactory,
                               IOutboundInterceptorFactory outboundInterceptorFactory,
-                              IRouter router,
-                              IPathFactory pathFactory)
+                              IPathGenerator pathGenerator,
+                              IRouter router)
         {
             _messagingFactory = messagingFactory;
             _router = router;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _brokeredMessageFactory = brokeredMessageFactory;
@@ -46,7 +46,7 @@ namespace Nimbus.Infrastructure.Events
             _knownMessageTypeVerifier.AssertValidMessageType(eventType);
 
             var brokeredMessage = await _brokeredMessageFactory.Create(busEvent);
-            var topicPath = _router.Route(eventType, QueueOrTopic.Topic, _pathFactory);
+            var topicPath = _router.Route(eventType, QueueOrTopic.Topic, _pathGenerator);
 
             using (var scope = _dependencyResolver.CreateChildScope())
             {

--- a/src/Nimbus/Infrastructure/Events/CompetingEventMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Events/CompetingEventMessagePumpsFactory.cs
@@ -21,6 +21,7 @@ namespace Nimbus.Infrastructure.Events
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
+        private readonly IPathFactory _pathFactory;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -34,7 +35,8 @@ namespace Nimbus.Infrastructure.Events
                                                  INimbusMessagingFactory messagingFactory,
                                                  INimbusTaskFactory taskFactory,
                                                  IRouter router,
-                                                 ITypeProvider typeProvider)
+                                                 ITypeProvider typeProvider,
+                                                 IPathFactory pathFactory)
         {
             _applicationName = applicationName;
             _clock = clock;
@@ -45,6 +47,7 @@ namespace Nimbus.Infrastructure.Events
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
+            _pathFactory = pathFactory;
             _taskFactory = taskFactory;
         }
 
@@ -56,7 +59,7 @@ namespace Nimbus.Infrastructure.Events
             // Events are routed to Topics and we'll create a competing subscription for the logical endpoint
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -74,7 +77,7 @@ namespace Nimbus.Infrastructure.Events
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = PathFactory.SubscriptionNameFor(_applicationName, handlerType);
+                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, handlerType);
 
                     _logger.Debug("Creating message pump for competing event subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/Events/CompetingEventMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Events/CompetingEventMessagePumpsFactory.cs
@@ -21,7 +21,7 @@ namespace Nimbus.Infrastructure.Events
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -34,9 +34,9 @@ namespace Nimbus.Infrastructure.Events
                                                  IMessageDispatcherFactory messageDispatcherFactory,
                                                  INimbusMessagingFactory messagingFactory,
                                                  INimbusTaskFactory taskFactory,
+                                                 IPathGenerator pathGenerator,
                                                  IRouter router,
-                                                 ITypeProvider typeProvider,
-                                                 IPathFactory pathFactory)
+                                                 ITypeProvider typeProvider)
         {
             _applicationName = applicationName;
             _clock = clock;
@@ -47,7 +47,7 @@ namespace Nimbus.Infrastructure.Events
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _taskFactory = taskFactory;
         }
 
@@ -59,7 +59,7 @@ namespace Nimbus.Infrastructure.Events
             // Events are routed to Topics and we'll create a competing subscription for the logical endpoint
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathGenerator)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -77,7 +77,7 @@ namespace Nimbus.Infrastructure.Events
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, handlerType);
+                    var subscriptionName = _pathGenerator.SubscriptionNameFor(_applicationName, handlerType);
 
                     _logger.Debug("Creating message pump for competing event subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/Events/MulticastEventMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Events/MulticastEventMessagePumpsFactory.cs
@@ -20,7 +20,7 @@ namespace Nimbus.Infrastructure.Events
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
 
@@ -36,9 +36,9 @@ namespace Nimbus.Infrastructure.Events
                                                    IMessageDispatcherFactory messageDispatcherFactory,
                                                    INimbusMessagingFactory messagingFactory,
                                                    INimbusTaskFactory taskFactory,
+                                                   IPathGenerator pathGenerator,
                                                    IRouter router,
-                                                   ITypeProvider typeProvider,
-                                                   IPathFactory pathFactory)
+                                                   ITypeProvider typeProvider)
         {
             _applicationName = applicationName;
             _instanceName = instanceName;
@@ -50,7 +50,7 @@ namespace Nimbus.Infrastructure.Events
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _taskFactory = taskFactory;
         }
 
@@ -62,7 +62,7 @@ namespace Nimbus.Infrastructure.Events
             // Events are routed to Topics and we'll create a subscription per instance of the logical endpoint to enable multicast behaviour
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathGenerator)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -80,7 +80,7 @@ namespace Nimbus.Infrastructure.Events
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, _instanceName, handlerType);
+                    var subscriptionName = _pathGenerator.SubscriptionNameFor(_applicationName, _instanceName, handlerType);
 
                     _logger.Debug("Creating message pump for multicast event subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/Events/MulticastEventMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/Events/MulticastEventMessagePumpsFactory.cs
@@ -20,6 +20,7 @@ namespace Nimbus.Infrastructure.Events
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
+        private readonly IPathFactory _pathFactory;
         private readonly INimbusMessagingFactory _messagingFactory;
         private readonly IRouter _router;
 
@@ -36,7 +37,8 @@ namespace Nimbus.Infrastructure.Events
                                                    INimbusMessagingFactory messagingFactory,
                                                    INimbusTaskFactory taskFactory,
                                                    IRouter router,
-                                                   ITypeProvider typeProvider)
+                                                   ITypeProvider typeProvider,
+                                                   IPathFactory pathFactory)
         {
             _applicationName = applicationName;
             _instanceName = instanceName;
@@ -48,6 +50,7 @@ namespace Nimbus.Infrastructure.Events
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
+            _pathFactory = pathFactory;
             _taskFactory = taskFactory;
         }
 
@@ -59,7 +62,7 @@ namespace Nimbus.Infrastructure.Events
             // Events are routed to Topics and we'll create a subscription per instance of the logical endpoint to enable multicast behaviour
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -77,7 +80,7 @@ namespace Nimbus.Infrastructure.Events
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = PathFactory.SubscriptionNameFor(_applicationName, _instanceName, handlerType);
+                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, _instanceName, handlerType);
 
                     _logger.Debug("Creating message pump for multicast event subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/PathFactory.cs
+++ b/src/Nimbus/Infrastructure/PathFactory.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Linq;
 using System.Text;
+using Nimbus.Routing;
 
 namespace Nimbus.Infrastructure
 {
-    public static class PathFactory
+    public class PathFactory : IPathFactory
     {
         private const string _queuePrefix = "q";
         private const string _topicPrefix = "t";
@@ -13,37 +14,37 @@ namespace Nimbus.Infrastructure
         // Entity segments can contain only letters, numbers, periods (.), hyphens (-), and underscores.
         private const string _queueCharacterWhitelist = "abcdefghijklmnopqrstuvwxyz1234567890.-";
 
-        public static string InputQueuePathFor(string applicationName, string instanceName)
+        public string InputQueuePathFor(string applicationName, string instanceName)
         {
             return Sanitize(string.Format("{0}.{1}.{2}", _instanceInputQueuePrefix, applicationName, instanceName));
         }
 
-        public static string QueuePathFor(Type type)
+        public string QueuePathFor(Type type)
         {
             return Sanitize(_queuePrefix + "." + StripGenericQualification(type));
         }
 
-        public static string TopicPathFor(Type type)
+        public string TopicPathFor(Type type)
         {
             return Sanitize(_topicPrefix + "." + StripGenericQualification(type));
         }
 
-        public static string SubscriptionNameFor(string applicationName)
+        public string SubscriptionNameFor(string applicationName)
         {
             return Shorten(Sanitize(applicationName), 50);
         }
 
-        public static string SubscriptionNameFor(string applicationName, string instanceName)
+        public string SubscriptionNameFor(string applicationName, string instanceName)
         {
             return Shorten(Sanitize(string.Join(".", new[] {applicationName, instanceName})), 50);
         }
 
-        public static string SubscriptionNameFor(string applicationName, Type handlerType)
+        public string SubscriptionNameFor(string applicationName, Type handlerType)
         {
             return Shorten(Sanitize(string.Join(".", new[] {applicationName, handlerType.Name})), 50);
         }
 
-        public static string SubscriptionNameFor(string applicationName, string instanceName, Type handlerType)
+        public string SubscriptionNameFor(string applicationName, string instanceName, Type handlerType)
         {
             return Shorten(Sanitize(string.Join(".", new[] {applicationName, instanceName, handlerType.Name})), 50);
         }

--- a/src/Nimbus/Infrastructure/PathGenerator.cs
+++ b/src/Nimbus/Infrastructure/PathGenerator.cs
@@ -5,7 +5,7 @@ using Nimbus.Routing;
 
 namespace Nimbus.Infrastructure
 {
-    public class PathFactory : IPathFactory
+    public class PathGenerator : IPathGenerator
     {
         private const string _queuePrefix = "q";
         private const string _topicPrefix = "t";

--- a/src/Nimbus/Infrastructure/RequestResponse/BusMulticastRequestSender.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/BusMulticastRequestSender.cs
@@ -18,6 +18,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IRouter _router;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly RequestResponseCorrelator _requestResponseCorrelator;
+        private readonly IPathFactory _pathFactory;
         private readonly IClock _clock;
         private readonly ILogger _logger;
         private readonly IKnownMessageTypeVerifier _knownMessageTypeVerifier;
@@ -32,12 +33,14 @@ namespace Nimbus.Infrastructure.RequestResponse
                                          INimbusMessagingFactory messagingFactory,
                                          IOutboundInterceptorFactory outboundInterceptorFactory,
                                          IRouter router,
-                                         RequestResponseCorrelator requestResponseCorrelator)
+                                         RequestResponseCorrelator requestResponseCorrelator,
+                                         IPathFactory pathFactory)
         {
             _messagingFactory = messagingFactory;
             _router = router;
             _brokeredMessageFactory = brokeredMessageFactory;
             _requestResponseCorrelator = requestResponseCorrelator;
+            _pathFactory = pathFactory;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _clock = clock;
@@ -52,7 +55,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             var requestType = busRequest.GetType();
             _knownMessageTypeVerifier.AssertValidMessageType(requestType);
 
-            var topicPath = _router.Route(requestType, QueueOrTopic.Topic);
+            var topicPath = _router.Route(requestType, QueueOrTopic.Topic, _pathFactory);
 
             var brokeredMessage = (await _brokeredMessageFactory.Create(busRequest))
                 .WithRequestTimeout(timeout)

--- a/src/Nimbus/Infrastructure/RequestResponse/BusMulticastRequestSender.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/BusMulticastRequestSender.cs
@@ -18,7 +18,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IRouter _router;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly RequestResponseCorrelator _requestResponseCorrelator;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly IClock _clock;
         private readonly ILogger _logger;
         private readonly IKnownMessageTypeVerifier _knownMessageTypeVerifier;
@@ -32,15 +32,15 @@ namespace Nimbus.Infrastructure.RequestResponse
                                          ILogger logger,
                                          INimbusMessagingFactory messagingFactory,
                                          IOutboundInterceptorFactory outboundInterceptorFactory,
+                                         IPathGenerator pathGenerator,
                                          IRouter router,
-                                         RequestResponseCorrelator requestResponseCorrelator,
-                                         IPathFactory pathFactory)
+                                         RequestResponseCorrelator requestResponseCorrelator)
         {
             _messagingFactory = messagingFactory;
             _router = router;
             _brokeredMessageFactory = brokeredMessageFactory;
             _requestResponseCorrelator = requestResponseCorrelator;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _dependencyResolver = dependencyResolver;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _clock = clock;
@@ -55,7 +55,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             var requestType = busRequest.GetType();
             _knownMessageTypeVerifier.AssertValidMessageType(requestType);
 
-            var topicPath = _router.Route(requestType, QueueOrTopic.Topic, _pathFactory);
+            var topicPath = _router.Route(requestType, QueueOrTopic.Topic, _pathGenerator);
 
             var brokeredMessage = (await _brokeredMessageFactory.Create(busRequest))
                 .WithRequestTimeout(timeout)

--- a/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
@@ -18,6 +18,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IRouter _router;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly RequestResponseCorrelator _requestResponseCorrelator;
+        private readonly IPathFactory _pathFactory;
         private readonly ILogger _logger;
         private readonly IClock _clock;
         private readonly DefaultTimeoutSetting _responseTimeout;
@@ -34,12 +35,14 @@ namespace Nimbus.Infrastructure.RequestResponse
                                   INimbusMessagingFactory messagingFactory,
                                   IOutboundInterceptorFactory outboundInterceptorFactory,
                                   IRouter router,
-                                  RequestResponseCorrelator requestResponseCorrelator)
+                                  RequestResponseCorrelator requestResponseCorrelator,
+                                  IPathFactory pathFactory)
         {
             _messagingFactory = messagingFactory;
             _router = router;
             _brokeredMessageFactory = brokeredMessageFactory;
             _requestResponseCorrelator = requestResponseCorrelator;
+            _pathFactory = pathFactory;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _dependencyResolver = dependencyResolver;
             _logger = logger;
@@ -62,7 +65,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             var requestType = busRequest.GetType();
             _knownMessageTypeVerifier.AssertValidMessageType(requestType);
 
-            var queuePath = _router.Route(requestType, QueueOrTopic.Queue);
+            var queuePath = _router.Route(requestType, QueueOrTopic.Queue, _pathFactory);
 
             var brokeredMessage = (await _brokeredMessageFactory.Create(busRequest))
                 .WithRequestTimeout(timeout)

--- a/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/BusRequestSender.cs
@@ -18,7 +18,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IRouter _router;
         private readonly IBrokeredMessageFactory _brokeredMessageFactory;
         private readonly RequestResponseCorrelator _requestResponseCorrelator;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
         private readonly ILogger _logger;
         private readonly IClock _clock;
         private readonly DefaultTimeoutSetting _responseTimeout;
@@ -34,15 +34,15 @@ namespace Nimbus.Infrastructure.RequestResponse
                                   ILogger logger,
                                   INimbusMessagingFactory messagingFactory,
                                   IOutboundInterceptorFactory outboundInterceptorFactory,
+                                  IPathGenerator pathGenerator,
                                   IRouter router,
-                                  RequestResponseCorrelator requestResponseCorrelator,
-                                  IPathFactory pathFactory)
+                                  RequestResponseCorrelator requestResponseCorrelator)
         {
             _messagingFactory = messagingFactory;
             _router = router;
             _brokeredMessageFactory = brokeredMessageFactory;
             _requestResponseCorrelator = requestResponseCorrelator;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _outboundInterceptorFactory = outboundInterceptorFactory;
             _dependencyResolver = dependencyResolver;
             _logger = logger;
@@ -65,7 +65,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             var requestType = busRequest.GetType();
             _knownMessageTypeVerifier.AssertValidMessageType(requestType);
 
-            var queuePath = _router.Route(requestType, QueueOrTopic.Queue, _pathFactory);
+            var queuePath = _router.Route(requestType, QueueOrTopic.Queue, _pathGenerator);
 
             var brokeredMessage = (await _brokeredMessageFactory.Create(busRequest))
                 .WithRequestTimeout(timeout)

--- a/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessagePumpsFactory.cs
@@ -21,7 +21,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -34,9 +34,9 @@ namespace Nimbus.Infrastructure.RequestResponse
                                                    IMessageDispatcherFactory messageDispatcherFactory,
                                                    INimbusMessagingFactory messagingFactory,
                                                    INimbusTaskFactory taskFactory,
+                                                   IPathGenerator pathGenerator,
                                                    IRouter router,
-                                                   ITypeProvider typeProvider,
-                                                   IPathFactory pathFactory)
+                                                   ITypeProvider typeProvider)
         {
             _applicationName = applicationName;
             _clock = clock;
@@ -47,7 +47,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _taskFactory = taskFactory;
         }
 
@@ -59,7 +59,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             // Events are routed to Topics and we'll create a competing subscription for the logical endpoint
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathGenerator)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -77,7 +77,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, handlerType);
+                    var subscriptionName = _pathGenerator.SubscriptionNameFor(_applicationName, handlerType);
 
                     _logger.Debug("Creating message pump for multicast request subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessagePumpsFactory.cs
@@ -21,6 +21,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
+        private readonly IPathFactory _pathFactory;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -34,7 +35,8 @@ namespace Nimbus.Infrastructure.RequestResponse
                                                    INimbusMessagingFactory messagingFactory,
                                                    INimbusTaskFactory taskFactory,
                                                    IRouter router,
-                                                   ITypeProvider typeProvider)
+                                                   ITypeProvider typeProvider,
+                                                   IPathFactory pathFactory)
         {
             _applicationName = applicationName;
             _clock = clock;
@@ -45,6 +47,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             _messagingFactory = messagingFactory;
             _router = router;
             _typeProvider = typeProvider;
+            _pathFactory = pathFactory;
             _taskFactory = taskFactory;
         }
 
@@ -56,7 +59,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             // Events are routed to Topics and we'll create a competing subscription for the logical endpoint
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic)})
+                .Select(m => new {MessageType = m, TopicPath = _router.Route(m, QueueOrTopic.Topic, _pathFactory)})
                 .GroupBy(b => b.TopicPath)
                 .Select(g => new
                              {
@@ -74,7 +77,7 @@ namespace Nimbus.Infrastructure.RequestResponse
                 foreach (var handlerType in binding.HandlerTypes)
                 {
                     var messageType = binding.MessageTypes.Single();
-                    var subscriptionName = PathFactory.SubscriptionNameFor(_applicationName, handlerType);
+                    var subscriptionName = _pathFactory.SubscriptionNameFor(_applicationName, handlerType);
 
                     _logger.Debug("Creating message pump for multicast request subscription '{0}/{1}' handling {2}", binding.TopicPath, subscriptionName, messageType);
                     var messageReceiver = _messagingFactory.GetTopicReceiver(binding.TopicPath, subscriptionName);

--- a/src/Nimbus/Infrastructure/RequestResponse/RequestMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/RequestMessagePumpsFactory.cs
@@ -20,6 +20,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
+        private readonly IPathFactory _pathFactory;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -32,7 +33,8 @@ namespace Nimbus.Infrastructure.RequestResponse
                                           INimbusMessagingFactory messagingFactory,
                                           INimbusTaskFactory taskFactory,
                                           IRouter router,
-                                          ITypeProvider typeProvider)
+                                          ITypeProvider typeProvider,
+                                          IPathFactory pathFactory)
         {
             _logger = logger;
             _messageDispatcherFactory = messageDispatcherFactory;
@@ -40,6 +42,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             _dispatchContextManager = dispatchContextManager;
             _handlerMapper = handlerMapper;
             _typeProvider = typeProvider;
+            _pathFactory = pathFactory;
             _taskFactory = taskFactory;
             _messagingFactory = messagingFactory;
             _router = router;
@@ -53,7 +56,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             // Create a single connection to each request queue determined by routing
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue)})
+                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathFactory)})
                 .GroupBy(b => b.QueuePath)
                 .Select(g => new {QueuePath = g.Key, HandlerTypes = g.SelectMany(x => _handlerMapper.GetHandlerTypesFor(openGenericHandlerType, x.MessageType))});
 

--- a/src/Nimbus/Infrastructure/RequestResponse/RequestMessagePumpsFactory.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/RequestMessagePumpsFactory.cs
@@ -20,7 +20,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IDispatchContextManager _dispatchContextManager;
         private readonly IHandlerMapper _handlerMapper;
         private readonly ITypeProvider _typeProvider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
 
         private readonly GarbageMan _garbageMan = new GarbageMan();
         private readonly INimbusTaskFactory _taskFactory;
@@ -32,9 +32,9 @@ namespace Nimbus.Infrastructure.RequestResponse
                                           IMessageDispatcherFactory messageDispatcherFactory,
                                           INimbusMessagingFactory messagingFactory,
                                           INimbusTaskFactory taskFactory,
+                                          IPathGenerator pathGenerator,
                                           IRouter router,
-                                          ITypeProvider typeProvider,
-                                          IPathFactory pathFactory)
+                                          ITypeProvider typeProvider)
         {
             _logger = logger;
             _messageDispatcherFactory = messageDispatcherFactory;
@@ -42,7 +42,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             _dispatchContextManager = dispatchContextManager;
             _handlerMapper = handlerMapper;
             _typeProvider = typeProvider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
             _taskFactory = taskFactory;
             _messagingFactory = messagingFactory;
             _router = router;
@@ -56,7 +56,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             // Create a single connection to each request queue determined by routing
             var allMessageTypesHandledByThisEndpoint = _handlerMapper.GetMessageTypesHandledBy(openGenericHandlerType, handlerTypes);
             var bindings = allMessageTypesHandledByThisEndpoint
-                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathFactory)})
+                .Select(m => new {MessageType = m, QueuePath = _router.Route(m, QueueOrTopic.Queue, _pathGenerator)})
                 .GroupBy(b => b.QueuePath)
                 .Select(g => new {QueuePath = g.Key, HandlerTypes = g.SelectMany(x => _handlerMapper.GetHandlerTypesFor(openGenericHandlerType, x.MessageType))});
 

--- a/src/Nimbus/Infrastructure/Routing/DestinationPerMessageTypeRouter.cs
+++ b/src/Nimbus/Infrastructure/Routing/DestinationPerMessageTypeRouter.cs
@@ -6,14 +6,14 @@ namespace Nimbus.Infrastructure.Routing
 {
     public class DestinationPerMessageTypeRouter : IRouter
     {
-        public string Route(Type messageType, QueueOrTopic queueOrTopic)
+        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory)
         {
             switch (queueOrTopic)
             {
                 case QueueOrTopic.Queue:
-                    return PathFactory.QueuePathFor(messageType);
+                    return pathFactory.QueuePathFor(messageType);
                 case QueueOrTopic.Topic:
-                    return PathFactory.TopicPathFor(messageType);
+                    return pathFactory.TopicPathFor(messageType);
                 default:
                     throw new Exception("Cannot build a route for the message type '{0}'.".FormatWith(messageType.FullName));
             }

--- a/src/Nimbus/Infrastructure/Routing/DestinationPerMessageTypeRouter.cs
+++ b/src/Nimbus/Infrastructure/Routing/DestinationPerMessageTypeRouter.cs
@@ -6,14 +6,14 @@ namespace Nimbus.Infrastructure.Routing
 {
     public class DestinationPerMessageTypeRouter : IRouter
     {
-        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory)
+        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathGenerator pathGenerator)
         {
             switch (queueOrTopic)
             {
                 case QueueOrTopic.Queue:
-                    return pathFactory.QueuePathFor(messageType);
+                    return pathGenerator.QueuePathFor(messageType);
                 case QueueOrTopic.Topic:
-                    return pathFactory.TopicPathFor(messageType);
+                    return pathGenerator.TopicPathFor(messageType);
                 default:
                     throw new Exception("Cannot build a route for the message type '{0}'.".FormatWith(messageType.FullName));
             }

--- a/src/Nimbus/Infrastructure/Routing/SingleQueueAndTopicPerMessageTypeRouter.cs
+++ b/src/Nimbus/Infrastructure/Routing/SingleQueueAndTopicPerMessageTypeRouter.cs
@@ -21,19 +21,19 @@ namespace Nimbus.Infrastructure.Routing
             _singleRequestQueuePath = singleRequestQueuePath;
         }
 
-        public string Route(Type messageType, QueueOrTopic queueOrTopic)
+        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory)
         {
             switch (queueOrTopic)
             {
                 case QueueOrTopic.Queue:
                     if (typeof (IBusCommand).IsAssignableFrom(messageType))
                     {
-                        return _singleCommandQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic);
+                        return _singleCommandQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
                     }
 
                     if (messageType.IsClosedTypeOf(typeof (IBusRequest<,>)))
                     {
-                        return _singleRequestQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic);
+                        return _singleRequestQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
                     }
 
                     break;
@@ -41,7 +41,7 @@ namespace Nimbus.Infrastructure.Routing
                     break;
             }
 
-            return _fallbackRouter.Route(messageType, queueOrTopic);
+            return _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
         }
     }
 }

--- a/src/Nimbus/Infrastructure/Routing/SingleQueueAndTopicPerMessageTypeRouter.cs
+++ b/src/Nimbus/Infrastructure/Routing/SingleQueueAndTopicPerMessageTypeRouter.cs
@@ -21,19 +21,19 @@ namespace Nimbus.Infrastructure.Routing
             _singleRequestQueuePath = singleRequestQueuePath;
         }
 
-        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathFactory pathFactory)
+        public string Route(Type messageType, QueueOrTopic queueOrTopic, IPathGenerator pathGenerator)
         {
             switch (queueOrTopic)
             {
                 case QueueOrTopic.Queue:
                     if (typeof (IBusCommand).IsAssignableFrom(messageType))
                     {
-                        return _singleCommandQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
+                        return _singleCommandQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathGenerator);
                     }
 
                     if (messageType.IsClosedTypeOf(typeof (IBusRequest<,>)))
                     {
-                        return _singleRequestQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
+                        return _singleRequestQueuePath ?? _fallbackRouter.Route(messageType, queueOrTopic, pathGenerator);
                     }
 
                     break;
@@ -41,7 +41,7 @@ namespace Nimbus.Infrastructure.Routing
                     break;
             }
 
-            return _fallbackRouter.Route(messageType, queueOrTopic, pathFactory);
+            return _fallbackRouter.Route(messageType, queueOrTopic, pathGenerator);
         }
     }
 }

--- a/src/Nimbus/Infrastructure/TypeProviderValidator.cs
+++ b/src/Nimbus/Infrastructure/TypeProviderValidator.cs
@@ -3,16 +3,19 @@ using System.Collections.Generic;
 using System.Linq;
 using Nimbus.Configuration;
 using Nimbus.Extensions;
+using Nimbus.Routing;
 
 namespace Nimbus.Infrastructure
 {
     public class TypeProviderValidator : IValidatableConfigurationSetting
     {
         private readonly ITypeProvider _provider;
+        private readonly IPathFactory _pathFactory;
 
-        public TypeProviderValidator(ITypeProvider provider)
+        public TypeProviderValidator(ITypeProvider provider, IPathFactory pathFactory)
         {
             _provider = provider;
+            _pathFactory = pathFactory;
         }
 
         public IEnumerable<string> Validate()
@@ -39,7 +42,7 @@ namespace Nimbus.Infrastructure
         private IEnumerable<string> CheckForDuplicateQueueNames()
         {
             var duplicateQueues = _provider.AllMessageContractTypes()
-                                      .Select(t => new Tuple<string, Type>(PathFactory.QueuePathFor(t), t))
+                                      .Select(t => new Tuple<string, Type>(_pathFactory.QueuePathFor(t), t))
                                       .GroupBy(tuple => tuple.Item1)
                                       .Where(tuple => tuple.Count() > 1)
                                       .ToArray();

--- a/src/Nimbus/Infrastructure/TypeProviderValidator.cs
+++ b/src/Nimbus/Infrastructure/TypeProviderValidator.cs
@@ -10,12 +10,12 @@ namespace Nimbus.Infrastructure
     public class TypeProviderValidator : IValidatableConfigurationSetting
     {
         private readonly ITypeProvider _provider;
-        private readonly IPathFactory _pathFactory;
+        private readonly IPathGenerator _pathGenerator;
 
-        public TypeProviderValidator(ITypeProvider provider, IPathFactory pathFactory)
+        public TypeProviderValidator(IPathGenerator pathGenerator, ITypeProvider provider)
         {
             _provider = provider;
-            _pathFactory = pathFactory;
+            _pathGenerator = pathGenerator;
         }
 
         public IEnumerable<string> Validate()
@@ -42,7 +42,7 @@ namespace Nimbus.Infrastructure
         private IEnumerable<string> CheckForDuplicateQueueNames()
         {
             var duplicateQueues = _provider.AllMessageContractTypes()
-                                      .Select(t => new Tuple<string, Type>(_pathFactory.QueuePathFor(t), t))
+                                      .Select(t => new Tuple<string, Type>(_pathGenerator.QueuePathFor(t), t))
                                       .GroupBy(tuple => tuple.Item1)
                                       .Where(tuple => tuple.Count() > 1)
                                       .ToArray();

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -175,7 +175,7 @@
     <Compile Include="Infrastructure\AssemblyScanningTypeProvider.cs" />
     <Compile Include="Configuration\Debug\BusBuilderDebuggingConfiguration.cs" />
     <Compile Include="Configuration\BusBuilderDebuggingConfigurationExtensions.cs" />
-    <Compile Include="Infrastructure\PathFactory.cs" />
+    <Compile Include="Infrastructure\PathGenerator.cs" />
     <Compile Include="Infrastructure\MessageSendersAndReceivers\INimbusMessageReceiver.cs" />
     <Compile Include="Infrastructure\MessageSendersAndReceivers\INimbusMessageSender.cs" />
     <Compile Include="Infrastructure\RequestResponse\ResponseMessageDispatcher.cs" />

--- a/src/Samples/PingPong.PathFactory/App.config
+++ b/src/Samples/PingPong.PathFactory/App.config
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+
+  <appSettings>
+    
+    <!-- Service Bus specific app setings for messaging connections -->
+    <add key="AzureConnectionString" value="Endpoint=sb://bgale-nimbusdev.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c37WIXBepw/cnPTMu22rzhuqiRFYC7qWspV1vpLzKsA=" />
+  <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://bgale-nimbusdev.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c37WIXBepw/cnPTMu22rzhuqiRFYC7qWspV1vpLzKsA=" /></appSettings>
+
+<system.serviceModel>
+    <extensions>
+      <!-- In this extension section we are introducing all known service bus extensions. User can remove the ones they don't need. -->
+      <behaviorExtensions>
+        <add name="connectionStatusBehavior" type="Microsoft.ServiceBus.Configuration.ConnectionStatusElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="transportClientEndpointBehavior" type="Microsoft.ServiceBus.Configuration.TransportClientEndpointBehaviorElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="serviceRegistrySettings" type="Microsoft.ServiceBus.Configuration.ServiceRegistrySettingsElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </behaviorExtensions>
+      <bindingElementExtensions>
+        <add name="netMessagingTransport" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingTransportExtensionElement, Microsoft.ServiceBus,  Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="tcpRelayTransport" type="Microsoft.ServiceBus.Configuration.TcpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="httpsRelayTransport" type="Microsoft.ServiceBus.Configuration.HttpsRelayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="onewayRelayTransport" type="Microsoft.ServiceBus.Configuration.RelayedOnewayTransportElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingElementExtensions>
+      <bindingExtensions>
+        <add name="basicHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.BasicHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="webHttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WebHttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="ws2007HttpRelayBinding" type="Microsoft.ServiceBus.Configuration.WS2007HttpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netTcpRelayBinding" type="Microsoft.ServiceBus.Configuration.NetTcpRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netOnewayRelayBinding" type="Microsoft.ServiceBus.Configuration.NetOnewayRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netEventRelayBinding" type="Microsoft.ServiceBus.Configuration.NetEventRelayBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+        <add name="netMessagingBinding" type="Microsoft.ServiceBus.Messaging.Configuration.NetMessagingBindingCollectionElement, Microsoft.ServiceBus, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      </bindingExtensions>
+    </extensions>
+  </system.serviceModel></configuration>

--- a/src/Samples/PingPong.PathFactory/CustomPathGenerator.cs
+++ b/src/Samples/PingPong.PathFactory/CustomPathGenerator.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Nimbus.Routing;
+
+namespace PingPong.PathGenerator
+{
+    public class CustomPathGenerator : IPathGenerator
+    {
+        // I've just stuck epic on the front to show it working...
+
+        private const string _queuePrefix = "epic-q";
+        private const string _topicPrefix = "epic-t";
+        private const string _instanceInputQueuePrefix = "inputqueue";
+
+        // Entity segments can contain only letters, numbers, periods (.), hyphens (-), and underscores.
+        private const string _queueCharacterWhitelist = "abcdefghijklmnopqrstuvwxyz1234567890.-";
+
+        public string InputQueuePathFor(string applicationName, string instanceName)
+        {
+            return Sanitize(string.Format("{0}.{1}.{2}", _instanceInputQueuePrefix, applicationName, instanceName));
+        }
+
+        public string QueuePathFor(Type type)
+        {
+            return Sanitize(_queuePrefix + "." + StripGenericQualification(type));
+        }
+
+        public string TopicPathFor(Type type)
+        {
+            return Sanitize(_topicPrefix + "." + StripGenericQualification(type));
+        }
+
+        public string SubscriptionNameFor(string applicationName)
+        {
+            return Shorten(Sanitize(applicationName), 50);
+        }
+
+        public string SubscriptionNameFor(string applicationName, string instanceName)
+        {
+            return Shorten(Sanitize(string.Join(".", new[] {applicationName, instanceName})), 50);
+        }
+
+        public string SubscriptionNameFor(string applicationName, Type handlerType)
+        {
+            return Shorten(Sanitize(string.Join(".", new[] {applicationName, handlerType.Name})), 50);
+        }
+
+        public string SubscriptionNameFor(string applicationName, string instanceName, Type handlerType)
+        {
+            return Shorten(Sanitize(string.Join(".", new[] {applicationName, instanceName, handlerType.Name})), 50);
+        }
+
+        private static string StripGenericQualification(Type type)
+        {
+            if (! type.IsGenericType) return type.FullName;
+
+            var genericArgs = type.GetGenericArguments().Select(arg => arg.Name);
+
+            return type.Namespace + "." + type.Name + "-" + string.Join("-", genericArgs);
+        }
+
+        private static string Sanitize(string path)
+        {
+            path = string.Join("", path.ToLower().ToCharArray().Select(SanitiseCharacter));
+            return path;
+        }
+
+        private static string Shorten(string path, int maxlength)
+        {
+            if (path.Length <= maxlength)
+                return path;
+
+            var hash = CalculateAdler32Hash(path);
+
+            var shortPath = path.Substring(0, maxlength - hash.Length) + hash;
+            return shortPath;
+        }
+
+        private static char SanitiseCharacter(char currentChar)
+        {
+            var whiteList = _queueCharacterWhitelist.ToCharArray();
+
+            if (!whiteList.Contains(currentChar))
+                return '.';
+
+            return currentChar;
+        }
+
+        private static string CalculateAdler32Hash(string inputString)
+        {
+            const uint BASE = 65521;
+            var buffer = Encoding.UTF8.GetBytes(inputString);
+            uint checksum = 1;
+            var offset = 0;
+            var count = buffer.Length;
+
+            var s1 = checksum & 0xFFFF;
+            var s2 = checksum >> 16;
+
+            while (count > 0)
+            {
+                var n = 3800;
+                if (n > count)
+                {
+                    n = count;
+                }
+                count -= n;
+                while (--n >= 0)
+                {
+                    s1 = s1 + (uint) (buffer[offset++] & 0xff);
+                    s2 = s2 + s1;
+                }
+                s1 %= BASE;
+                s2 %= BASE;
+            }
+
+            checksum = (s2 << 16) | s1;
+            return checksum.ToString();
+        }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/IPinger.cs
+++ b/src/Samples/PingPong.PathFactory/IPinger.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace PingPong.PathGenerator
+{
+    public interface IPinger
+    {
+        Task<string> Ping(string message);
+    }
+}

--- a/src/Samples/PingPong.PathFactory/Ping.cs
+++ b/src/Samples/PingPong.PathFactory/Ping.cs
@@ -1,0 +1,9 @@
+﻿using Nimbus.MessageContracts;
+
+namespace PingPong.PathGenerator
+{
+    public class Ping : BusRequest<Ping, Pong>
+    {
+        public string Message { get; set; }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/PingPong.PathGenerator.csproj
+++ b/src/Samples/PingPong.PathFactory/PingPong.PathGenerator.csproj
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8D396B69-2B57-4B23-AE89-7EA80302F1FB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PingPong.PathGenerator</RootNamespace>
+    <AssemblyName>PingPong.PathGenerator</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1998</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <NoWarn>1998</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IPinger.cs" />
+    <Compile Include="CustomPathGenerator.cs" />
+    <Compile Include="Ping.cs" />
+    <Compile Include="Pinger.cs" />
+    <Compile Include="Pong.cs" />
+    <Compile Include="Ponger.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Extensions\Nimbus.Logger.Serilog\Nimbus.Logger.Serilog.csproj">
+      <Project>{6B665505-3C52-49D3-914A-7C295AF3F877}</Project>
+      <Name>Nimbus.Logger.Serilog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Extensions\Nimbus.Serializers.Json\Nimbus.Serializers.Json.csproj">
+      <Project>{109FB118-FA9A-4EB2-88AF-F66C973CE50F}</Project>
+      <Name>Nimbus.Serializers.Json</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Extensions\Nimbus.Windsor\Nimbus.Windsor.csproj">
+      <Project>{7fcf3124-24ec-40ca-95fd-e30315d0dde2}</Project>
+      <Name>Nimbus.Windsor</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Nimbus.InfrastructureContracts\Nimbus.InfrastructureContracts.csproj">
+      <Project>{D59397D3-F595-45AB-9BF8-4615C298545B}</Project>
+      <Name>Nimbus.InfrastructureContracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Nimbus.MessageContracts\Nimbus.MessageContracts.csproj">
+      <Project>{702a4f7e-97c5-4651-b704-65c6d0d70c1c}</Project>
+      <Name>Nimbus.MessageContracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Nimbus\Nimbus.csproj">
+      <Project>{1b793c01-e824-4449-b93d-277626b1791f}</Project>
+      <Name>Nimbus</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Samples/PingPong.PathFactory/Pinger.cs
+++ b/src/Samples/PingPong.PathFactory/Pinger.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nimbus;
+
+namespace PingPong.PathGenerator
+{
+    public class Pinger : IPinger
+    {
+        private readonly IBus _bus;
+
+        public Pinger(IBus bus)
+        {
+            _bus = bus;
+        }
+
+        public async Task<string> Ping(string message)
+        {
+            Console.WriteLine("Sending message: '{0}'", message);
+            var response = await _bus.Request(new Ping {Message = (message.ToLowerInvariant() == "ping" ? "Pong" : message)});
+            return response.Message;
+        }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/Pong.cs
+++ b/src/Samples/PingPong.PathFactory/Pong.cs
@@ -1,0 +1,9 @@
+﻿using Nimbus.MessageContracts;
+
+namespace PingPong.PathGenerator
+{
+    public class Pong : IBusResponse
+    {
+        public string Message { get; set; }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/Ponger.cs
+++ b/src/Samples/PingPong.PathFactory/Ponger.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Nimbus.Handlers;
+
+namespace PingPong.PathGenerator
+{
+    public class Ponger : IHandleRequest<Ping, Pong>
+    {
+        public async Task<Pong> Handle(Ping request)
+        {
+            return new Pong {Message = request.Message};
+        }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/Program.cs
+++ b/src/Samples/PingPong.PathFactory/Program.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Configuration;
+using System.Reflection;
+using System.Threading;
+using Nimbus;
+using Nimbus.Configuration;
+using Nimbus.Infrastructure;
+
+namespace PingPong.PathGenerator
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            var bus = SetUpBus();
+
+            Console.WriteLine("Enter some text to have it ponged back at you. Type 'exit' to quit...");
+
+            var exit = new ManualResetEvent(false);
+            Start(new Pinger(bus), exit);
+
+            exit.WaitOne();
+        }
+
+        private static async void Start(IPinger pinger, ManualResetEvent exit)
+        {
+            while (true)
+            {
+                var input = Console.ReadLine();
+                if (input != null && input.ToLowerInvariant() == "exit")
+                {
+                    exit.Set();
+                }
+                else
+                {
+                    var pong = await pinger.Ping(input);
+                    Console.WriteLine(pong);
+                }
+            }
+        }
+
+        private static IBus SetUpBus()
+        {
+            //TODO: Set up your own connection string in app.config
+            var connectionString = ConfigurationManager.AppSettings["AzureConnectionString"];
+
+            // This is how you tell Nimbus where to find all your message types and handlers.
+            var typeProvider = new AssemblyScanningTypeProvider(Assembly.GetExecutingAssembly());
+
+            var bus = new BusBuilder()
+                .Configure()
+                .WithConnectionString(connectionString)
+                .WithNames("PingPong.pathGenerator", Environment.MachineName)
+                .WithTypesFrom(typeProvider)
+                .WithJsonSerializer()
+                .WithDeflateCompressor()
+                .WithPathGenerator(new CustomPathGenerator())
+                .Build();
+            bus.Start().Wait();
+
+            return bus;
+        }
+    }
+}

--- a/src/Samples/PingPong.PathFactory/Properties/AssemblyInfo.cs
+++ b/src/Samples/PingPong.PathFactory/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("PingPong.Windsor")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PingPong.Windsor")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("c543592c-0366-4ed0-8e47-ee77e310adab")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Samples/PingPong.PathFactory/packages.config
+++ b/src/Samples/PingPong.PathFactory/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net45" />
+</packages>

--- a/src/Samples/PizzaSample/Pizza.Maker/App.config
+++ b/src/Samples/PizzaSample/Pizza.Maker/App.config
@@ -5,7 +5,7 @@
     </startup>
 
   <appSettings>
-    <add key="AzureConnectionString" value="Endpoint=sb://nimbusdemo.servicebus.windows.net/;SharedSecretIssuer=owner;SharedSecretValue=ouj58pTpzfbBu3hfSnX2fI57jzZgIBPuHsovjryCJCo=" />
+    <add key="AzureConnectionString" value="Endpoint=sb://bgale-nimbusdev.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c37WIXBepw/cnPTMu22rzhuqiRFYC7qWspV1vpLzKsA=" />
   </appSettings>
 
 <system.serviceModel>

--- a/src/Samples/PizzaSample/Pizza.Ordering/App.config
+++ b/src/Samples/PizzaSample/Pizza.Ordering/App.config
@@ -6,8 +6,9 @@
 
   <appSettings>
     
-    <!-- Service Bus specific app setings for messaging connections --><add key="AzureConnectionString" value="Endpoint=sb://nimbusdemo.servicebus.windows.net/;SharedSecretIssuer=owner;SharedSecretValue=ouj58pTpzfbBu3hfSnX2fI57jzZgIBPuHsovjryCJCo=" />
-  <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://[your namespace].servicebus.windows.net;SharedSecretIssuer=owner;SharedSecretValue=[your secret]" /></appSettings>
+    <!-- Service Bus specific app setings for messaging connections -->
+    <add key="AzureConnectionString" value="Endpoint=sb://bgale-nimbusdev.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c37WIXBepw/cnPTMu22rzhuqiRFYC7qWspV1vpLzKsA=" />
+  <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=sb://bgale-nimbusdev.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=c37WIXBepw/cnPTMu22rzhuqiRFYC7qWspV1vpLzKsA=" /></appSettings>
 
 <system.serviceModel>
     <extensions>

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LargeMessageTests/WhenCreatingALargeMessageUsingTheUnsupportedMessageBodyStore.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LargeMessageTests/WhenCreatingALargeMessageUsingTheUnsupportedMessageBodyStore.cs
@@ -24,7 +24,7 @@ namespace Nimbus.IntegrationTests.Tests.LargeMessageTests
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),
                                               new MaxSmallMessageSizeSetting {Value = 64*1024},
-                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "SomeApp"}, new InstanceNameSetting {Value = "SomeInstance"}, new PathFactory()),
+                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "SomeApp"}, new InstanceNameSetting {Value = "SomeInstance"}, new PathGenerator()),
                                               new SystemClock(),
                                               new NullCompressor(),
                                               new DispatchContextManager(),

--- a/src/Tests/Nimbus.IntegrationTests/Tests/LargeMessageTests/WhenCreatingALargeMessageUsingTheUnsupportedMessageBodyStore.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/LargeMessageTests/WhenCreatingALargeMessageUsingTheUnsupportedMessageBodyStore.cs
@@ -24,7 +24,7 @@ namespace Nimbus.IntegrationTests.Tests.LargeMessageTests
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),
                                               new MaxSmallMessageSizeSetting {Value = 64*1024},
-                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "SomeApp"}, new InstanceNameSetting {Value = "SomeInstance"}),
+                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "SomeApp"}, new InstanceNameSetting {Value = "SomeInstance"}, new PathFactory()),
                                               new SystemClock(),
                                               new NullCompressor(),
                                               new DispatchContextManager(),

--- a/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAMessageTypeNameIsDuplicated.cs
+++ b/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAMessageTypeNameIsDuplicated.cs
@@ -13,7 +13,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void ValidationShouldFail()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(Assembly.GetAssembly(typeof (DuplicateMessageType)));
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider);
+            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
             typeProviderValidator.Validate().ShouldNotBeEmpty();
         }
     }

--- a/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAMessageTypeNameIsDuplicated.cs
+++ b/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAMessageTypeNameIsDuplicated.cs
@@ -13,7 +13,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void ValidationShouldFail()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(Assembly.GetAssembly(typeof (DuplicateMessageType)));
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
+            var typeProviderValidator = new TypeProviderValidator(new PathGenerator(), assemblyScanningTypeProvider);
             typeProviderValidator.Validate().ShouldNotBeEmpty();
         }
     }

--- a/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
+++ b/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
@@ -13,7 +13,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void ValidationShouldFail()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider);
+            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
             typeProviderValidator.Validate().ShouldNotBeEmpty();
         }
 
@@ -21,7 +21,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void TheMessageShouldMentionTheOffendingTypeByName()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider);
+            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
             var validationErrors = typeProviderValidator.Validate().ToArray();
 
             validationErrors.ShouldContain(e => e.Contains(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).FullName));

--- a/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
+++ b/src/Tests/Nimbus.UnitTests/AssemblyScanningTests/WhenAUnserializableAMessageThatIsInAnAssemblyThatIsNotIncluded.cs
@@ -13,7 +13,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void ValidationShouldFail()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
+            var typeProviderValidator = new TypeProviderValidator(new PathGenerator(),assemblyScanningTypeProvider);
             typeProviderValidator.Validate().ShouldNotBeEmpty();
         }
 
@@ -21,7 +21,7 @@ namespace Nimbus.UnitTests.AssemblyScanningTests
         public void TheMessageShouldMentionTheOffendingTypeByName()
         {
             var assemblyScanningTypeProvider = new AssemblyScanningTypeProvider(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).Assembly);
-            var typeProviderValidator = new TypeProviderValidator(assemblyScanningTypeProvider, new PathFactory());
+            var typeProviderValidator = new TypeProviderValidator(new PathGenerator(), assemblyScanningTypeProvider);
             var validationErrors = typeProviderValidator.Validate().ToArray();
 
             validationErrors.ShouldContain(e => e.Contains(typeof (UnserializableCommandWhoseAssemblyShouldNotBeIncluded).FullName));

--- a/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenPublishingACollectionOfEventsViaTheBusEventSender.cs
+++ b/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenPublishingACollectionOfEventsViaTheBusEventSender.cs
@@ -38,7 +38,7 @@ namespace Nimbus.UnitTests.BatchSendingTests
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
                 new InstanceNameSetting { Value = "TestInstance" },
-                new PathFactory());
+                new PathGenerator());
             var brokeredMessageFactory = new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                                                     new MaxLargeMessageSizeSetting(),
                                                                     new MaxSmallMessageSizeSetting(),
@@ -60,8 +60,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
                                                       logger,
                                                       messagingFactory,
                                                       outboundInterceptorFactory,
-                                                      router,
-                                                      new PathFactory());
+                                                      new PathGenerator(),
+                                                      router);
             return Task.FromResult(busCommandSender);
         }
 

--- a/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenPublishingACollectionOfEventsViaTheBusEventSender.cs
+++ b/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenPublishingACollectionOfEventsViaTheBusEventSender.cs
@@ -37,7 +37,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
             var serializer = new DataContractSerializer(typeProvider);
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
-                new InstanceNameSetting {Value = "TestInstance"});
+                new InstanceNameSetting { Value = "TestInstance" },
+                new PathFactory());
             var brokeredMessageFactory = new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                                                     new MaxLargeMessageSizeSetting(),
                                                                     new MaxSmallMessageSizeSetting(),
@@ -59,7 +60,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
                                                       logger,
                                                       messagingFactory,
                                                       outboundInterceptorFactory,
-                                                      router);
+                                                      router,
+                                                      new PathFactory());
             return Task.FromResult(busCommandSender);
         }
 

--- a/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenSendingACollectionOfCommandsViaTheCommandSender.cs
+++ b/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenSendingACollectionOfCommandsViaTheCommandSender.cs
@@ -38,7 +38,7 @@ namespace Nimbus.UnitTests.BatchSendingTests
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
                 new InstanceNameSetting {Value = "TestInstance"},
-                new PathFactory());
+                new PathGenerator());
             var brokeredMessageFactory = new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                                                     new MaxLargeMessageSizeSetting(),
                                                                     new MaxSmallMessageSizeSetting(),
@@ -61,8 +61,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
                                                         logger,
                                                         messagingFactory,
                                                         outboundInterceptorFactory,
-                                                        router,
-                                                        new PathFactory());
+                                                        new PathGenerator(),
+                                                        router);
             return Task.FromResult(busCommandSender);
         }
 

--- a/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenSendingACollectionOfCommandsViaTheCommandSender.cs
+++ b/src/Tests/Nimbus.UnitTests/BatchSendingTests/WhenSendingACollectionOfCommandsViaTheCommandSender.cs
@@ -37,7 +37,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
             var serializer = new DataContractSerializer(typeProvider);
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
-                new InstanceNameSetting {Value = "TestInstance"});
+                new InstanceNameSetting {Value = "TestInstance"},
+                new PathFactory());
             var brokeredMessageFactory = new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                                                     new MaxLargeMessageSizeSetting(),
                                                                     new MaxSmallMessageSizeSetting(),
@@ -60,7 +61,8 @@ namespace Nimbus.UnitTests.BatchSendingTests
                                                         logger,
                                                         messagingFactory,
                                                         outboundInterceptorFactory,
-                                                        router);
+                                                        router,
+                                                        new PathFactory());
             return Task.FromResult(busCommandSender);
         }
 

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/GivenABrokeredMessageFactory.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/GivenABrokeredMessageFactory.cs
@@ -22,7 +22,7 @@ namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
             _clock = Substitute.For<IClock>();
             _serializer = Substitute.For<ISerializer>();
 
-            ReplyQueueNameSetting = new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "TestApplication"}, new InstanceNameSetting {Value = "TestInstance"}, new PathFactory());
+            ReplyQueueNameSetting = new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "TestApplication"}, new InstanceNameSetting {Value = "TestInstance"}, new PathGenerator());
 
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/GivenABrokeredMessageFactory.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/GivenABrokeredMessageFactory.cs
@@ -22,7 +22,7 @@ namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
             _clock = Substitute.For<IClock>();
             _serializer = Substitute.For<ISerializer>();
 
-            ReplyQueueNameSetting = new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "TestApplication"}, new InstanceNameSetting {Value = "TestInstance"});
+            ReplyQueueNameSetting = new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "TestApplication"}, new InstanceNameSetting {Value = "TestInstance"}, new PathFactory());
 
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),

--- a/src/Tests/Nimbus.UnitTests/CompressionTests/WhenBuildingBrokeredMessagesUsingCompression.cs
+++ b/src/Tests/Nimbus.UnitTests/CompressionTests/WhenBuildingBrokeredMessagesUsingCompression.cs
@@ -36,7 +36,7 @@ namespace Nimbus.UnitTests.CompressionTests
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),
                                               new MaxSmallMessageSizeSetting(),
-                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "App"}, new InstanceNameSetting {Value = "Instance"}, new PathFactory()),
+                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "App"}, new InstanceNameSetting {Value = "Instance"}, new PathGenerator()),
                                               Substitute.For<IClock>(),
                                               compressor,
                                               new DispatchContextManager(),

--- a/src/Tests/Nimbus.UnitTests/CompressionTests/WhenBuildingBrokeredMessagesUsingCompression.cs
+++ b/src/Tests/Nimbus.UnitTests/CompressionTests/WhenBuildingBrokeredMessagesUsingCompression.cs
@@ -36,7 +36,7 @@ namespace Nimbus.UnitTests.CompressionTests
             return new BrokeredMessageFactory(new DefaultMessageTimeToLiveSetting(),
                                               new MaxLargeMessageSizeSetting(),
                                               new MaxSmallMessageSizeSetting(),
-                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "App"}, new InstanceNameSetting {Value = "Instance"}),
+                                              new ReplyQueueNameSetting(new ApplicationNameSetting {Value = "App"}, new InstanceNameSetting {Value = "Instance"}, new PathFactory()),
                                               Substitute.For<IClock>(),
                                               compressor,
                                               new DispatchContextManager(),

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
@@ -33,7 +33,8 @@ namespace Nimbus.UnitTests.DispatcherTests
             var clock = Substitute.For<IClock>();
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
-                new InstanceNameSetting {Value = "TestInstance"});
+                new InstanceNameSetting {Value = "TestInstance"},
+                new PathFactory());
             TypeProvider = new TestHarnessTypeProvider(new[] {GetType().Assembly}, new[] {GetType().Namespace});
             var serializer = new DataContractSerializer(TypeProvider);
             HandlerMapper = new HandlerMapper(TypeProvider);

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
@@ -34,7 +34,7 @@ namespace Nimbus.UnitTests.DispatcherTests
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
                 new InstanceNameSetting {Value = "TestInstance"},
-                new PathFactory());
+                new PathGenerator());
             TypeProvider = new TestHarnessTypeProvider(new[] {GetType().Assembly}, new[] {GetType().Namespace});
             var serializer = new DataContractSerializer(TypeProvider);
             HandlerMapper = new HandlerMapper(TypeProvider);

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingTwoCommands.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingTwoCommands.cs
@@ -43,7 +43,7 @@ namespace Nimbus.UnitTests.DispatcherTests
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
                 new InstanceNameSetting { Value = "TestInstance" },
-                new PathFactory());
+                new PathGenerator());
 
             var handlerMap = new HandlerMapper(typeProvider).GetFullHandlerMap(typeof (IHandleCommand<>));
 

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingTwoCommands.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/WhenDispatchingTwoCommands.cs
@@ -42,7 +42,8 @@ namespace Nimbus.UnitTests.DispatcherTests
             var serializer = new DataContractSerializer(typeProvider);
             var replyQueueNameSetting = new ReplyQueueNameSetting(
                 new ApplicationNameSetting {Value = "TestApplication"},
-                new InstanceNameSetting {Value = "TestInstance"});
+                new InstanceNameSetting { Value = "TestInstance" },
+                new PathFactory());
 
             var handlerMap = new HandlerMapper(typeProvider).GetFullHandlerMap(typeof (IHandleCommand<>));
 

--- a/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
+++ b/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
@@ -10,25 +10,25 @@ namespace Nimbus.UnitTests.InfrastructureTests
     [TestFixture]
     public class PathFactoryTests
     {
-        private PathFactory _pathFactory;
+        private PathGenerator _pathGenerator;
 
         [SetUp]
         public void Setup()
         {
-            _pathFactory = new PathFactory();
+            _pathGenerator = new PathGenerator();
         }
 
         [Test]
         public void WhenCreatingAQueueForANestedType_WeShouldStripOutPlusSigns()
         {
-            var pathName = _pathFactory.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
+            var pathName = _pathGenerator.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
             pathName.ShouldNotContain("+");
         }
 
         [Test]
         public void WhenCreatingAQueue_WeShouldConvertToLowerCase()
         {
-            var pathName = _pathFactory.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
+            var pathName = _pathGenerator.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
 
             var expectedName = "t." +
                                typeof (MyEscapingTestMessages.EscapingTestMessage).FullName.Replace("+", ".").ToLower();
@@ -39,14 +39,14 @@ namespace Nimbus.UnitTests.InfrastructureTests
         [Test]
         public void WhenCreatingAQueueForAGenericType_WeShouldStripOutBackticks()
         {
-            var pathName = _pathFactory.QueuePathFor(typeof(MyCommand<string>));
+            var pathName = _pathGenerator.QueuePathFor(typeof(MyCommand<string>));
             pathName.ShouldNotContain("`");
         }
 
         [Test]
         public void WhenCreatingAQueueForAGenericType_WeShouldShortenTheGenericTypeArgumentName()
         {
-            var pathName = _pathFactory.QueuePathFor(typeof(MyCommand<string>));
+            var pathName = _pathGenerator.QueuePathFor(typeof(MyCommand<string>));
 
             var expected = "q.nimbus.unittests.infrastructuretests.messagecontracts.mycommand.1-string";
 
@@ -56,7 +56,7 @@ namespace Nimbus.UnitTests.InfrastructureTests
         [Test]
         public void WhenCreatingASubscriptionForATypeWeHaveAMaximumLengthOf50()
         {
-            var pathName = _pathFactory.SubscriptionNameFor("MyLongApplicationName", "Appserver", typeof(MyEventWithALongName));
+            var pathName = _pathGenerator.SubscriptionNameFor("MyLongApplicationName", "Appserver", typeof(MyEventWithALongName));
             pathName.Length.ShouldBe(50);
         }
     }

--- a/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
+++ b/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
@@ -1,4 +1,6 @@
-﻿using Nimbus.Infrastructure;
+﻿using System.IO;
+using Nimbus.Infrastructure;
+using Nimbus.UnitTests.BatchSendingTests;
 using Nimbus.UnitTests.InfrastructureTests.MessageContracts;
 using NUnit.Framework;
 using Shouldly;
@@ -8,17 +10,25 @@ namespace Nimbus.UnitTests.InfrastructureTests
     [TestFixture]
     public class PathFactoryTests
     {
+        private PathFactory _pathFactory;
+
+        [SetUp]
+        public void Setup()
+        {
+            _pathFactory = new PathFactory();
+        }
+
         [Test]
         public void WhenCreatingAQueueForANestedType_WeShouldStripOutPlusSigns()
         {
-            var pathName = PathFactory.TopicPathFor(typeof (MyEscapingTestMessages.EscapingTestMessage));
+            var pathName = _pathFactory.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
             pathName.ShouldNotContain("+");
         }
 
         [Test]
         public void WhenCreatingAQueue_WeShouldConvertToLowerCase()
         {
-            var pathName = PathFactory.TopicPathFor(typeof (MyEscapingTestMessages.EscapingTestMessage));
+            var pathName = _pathFactory.TopicPathFor(typeof(MyEscapingTestMessages.EscapingTestMessage));
 
             var expectedName = "t." +
                                typeof (MyEscapingTestMessages.EscapingTestMessage).FullName.Replace("+", ".").ToLower();
@@ -29,14 +39,14 @@ namespace Nimbus.UnitTests.InfrastructureTests
         [Test]
         public void WhenCreatingAQueueForAGenericType_WeShouldStripOutBackticks()
         {
-            var pathName = PathFactory.QueuePathFor(typeof (MyCommand<string>));
+            var pathName = _pathFactory.QueuePathFor(typeof(MyCommand<string>));
             pathName.ShouldNotContain("`");
         }
 
         [Test]
         public void WhenCreatingAQueueForAGenericType_WeShouldShortenTheGenericTypeArgumentName()
         {
-            var pathName = PathFactory.QueuePathFor(typeof (MyCommand<string>));
+            var pathName = _pathFactory.QueuePathFor(typeof(MyCommand<string>));
 
             var expected = "q.nimbus.unittests.infrastructuretests.messagecontracts.mycommand.1-string";
 
@@ -46,7 +56,7 @@ namespace Nimbus.UnitTests.InfrastructureTests
         [Test]
         public void WhenCreatingASubscriptionForATypeWeHaveAMaximumLengthOf50()
         {
-            var pathName = PathFactory.SubscriptionNameFor("MyLongApplicationName", "Appserver", typeof (MyEventWithALongName));
+            var pathName = _pathFactory.SubscriptionNameFor("MyLongApplicationName", "Appserver", typeof(MyEventWithALongName));
             pathName.Length.ShouldBe(50);
         }
     }

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -10,6 +10,7 @@
   <repository path="..\Nimbus.InfrastructureContracts\packages.config" />
   <repository path="..\Nimbus\packages.config" />
   <repository path="..\Samples\Nimbus.SampleApp\packages.config" />
+  <repository path="..\Samples\PingPong.PathFactory\packages.config" />
   <repository path="..\Samples\PingPong.Windsor\packages.config" />
   <repository path="..\Samples\PizzaSample\Pizza.Maker\packages.config" />
   <repository path="..\Samples\PizzaSample\Pizza.Ordering\packages.config" />


### PR DESCRIPTION
We need the ability to have a finer control over the names generated within azure. For this I've made the component responsible injectable via an extension method. 
It defaults to the way things worked before so no changes would need to be made.