### PR TITLE
Generic brokered type

### DIFF
--- a/src/Extensions/Nimbus.Serializers.ProtoBuf/Nimbus.Serializers.ProtoBuf.nuspec
+++ b/src/Extensions/Nimbus.Serializers.ProtoBuf/Nimbus.Serializers.ProtoBuf.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Nimbus.Serializers.Protobuf</id>
     <version>$version$</version>
-    <title>Nimbus.Serializers.Json</title>
+    <title>Nimbus.Serializers.Protobuf</title>
     <authors>Ben Gale</authors>
     <owners>Ben Gale</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
We're currently working on an extension in our own branch that we'll PR when ready that uses generic wrappers on the messages.

Your queue implementation handles this well however the BrokeredMessageFactory doesn't. We get the fully qualified name including the version number of the package. The limitation here is that any projects using old libraries would no longer work if we were publishing from a new version, even if we were publishing unmodified messages.

To solve this we've re-utilised your code from the PathFactory. This means everything functions as before unless you pass generics, in which case it uses the name generated like in the queue names.