### PR TITLE
Added test to verify spaces are properly handled when sanitizing names.

### DIFF
--- a/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
+++ b/src/Tests/Nimbus.UnitTests/InfrastructureTests/PathFactoryTests.cs
@@ -49,5 +49,12 @@ namespace Nimbus.UnitTests.InfrastructureTests
             var pathName = PathFactory.SubscriptionNameFor("MyLongApplicationName", "Appserver", typeof (MyEventWithALongName));
             pathName.Length.ShouldBe(50);
         }
+
+        [Test]
+        public void WhenCreatingASubscriptionForATypeASpaceShouldBeConvertedToTheSanitizeCharacter()
+        {
+            var pathName = PathFactory.SubscriptionNameFor("My App", "App server", typeof(MyEventWithALongName));
+            pathName.ShouldBe("my.app.app.server.myeventwithalongname");
+        }
     }
 }


### PR DESCRIPTION
Closes #161. This work looks to already have been done by @uglybugger in a previous commit with the whitelist of good characters and then just changing all the other characters, so I just added a test to verify this is indeed closed.