### PR TITLE
BrokeredMessage Responses now use the Session ID set by the 'ReplyToSess...

### DIFF
--- a/src/Nimbus/Extensions/BrokeredMessageExtensions.cs
+++ b/src/Nimbus/Extensions/BrokeredMessageExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ServiceBus.Messaging;
 using Nimbus.Infrastructure;
+using NullGuard;
 
 namespace Nimbus.Extensions
 {
@@ -44,6 +45,12 @@ namespace Nimbus.Extensions
         internal static BrokeredMessage WithReplyTo(this BrokeredMessage message, string replyTo)
         {
             message.ReplyTo = replyTo;
+            return message;
+        }
+
+        internal static BrokeredMessage WithSessionId(this BrokeredMessage message, [AllowNull] string sessionId)
+        {
+            message.SessionId = sessionId;
             return message;
         }
 

--- a/src/Nimbus/Infrastructure/BrokeredMessageServices/BrokeredMessageFactory.cs
+++ b/src/Nimbus/Infrastructure/BrokeredMessageServices/BrokeredMessageFactory.cs
@@ -96,7 +96,9 @@ namespace Nimbus.Infrastructure.BrokeredMessageServices
         {
             return Task.Run(async () =>
                                   {
-                                      var responseMessage = (await Create(responseContent)).WithReplyToRequestId(originalRequest.MessageId);
+                                      var responseMessage = (await Create(responseContent))
+                                                                    .WithReplyToRequestId(originalRequest.MessageId)
+                                                                    .WithSessionId(originalRequest.ReplyToSessionId);
                                       responseMessage.Properties[MessagePropertyKeys.RequestSuccessful] = true;
 
                                       return responseMessage;
@@ -107,7 +109,9 @@ namespace Nimbus.Infrastructure.BrokeredMessageServices
         {
             return Task.Run(async () =>
                                   {
-                                      var responseMessage = (await Create()).WithReplyToRequestId(originalRequest.MessageId);
+                                      var responseMessage = (await Create())
+                                                                    .WithReplyToRequestId(originalRequest.MessageId)
+                                                                    .WithSessionId(originalRequest.ReplyToSessionId);
                                       responseMessage.Properties[MessagePropertyKeys.RequestSuccessful] = false;
                                       foreach (var prop in exception.ExceptionDetailsAsProperties(_clock.UtcNow)) responseMessage.Properties.Add(prop.Key, prop.Value);
 

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingAFailedResponseToARequestWithReplyToSessionIdNotSet.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingAFailedResponseToARequestWithReplyToSessionIdNotSet.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
+{
+    [TestFixture]
+    internal class WhenCreatingAFailedResponseToARequestWithReplyToSessionIdNotSet : GivenABrokeredMessageFactory
+    {
+        private BrokeredMessage _request;
+        private BrokeredMessage _response;
+
+        protected override async Task When()
+        {
+            _request = new BrokeredMessage();
+            _response = await Subject.CreateFailedResponse(_request, new Exception());
+        }
+
+        [Test]
+        public void ThenTheResponseShouldNotHaveSessionIdSet()
+        {
+            _response.SessionId.ShouldBe(null);
+        }
+
+        [DataContract]
+        public class TestResponse { }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingAFailedResponseToARequestWithReplyToSessionIdSet.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingAFailedResponseToARequestWithReplyToSessionIdSet.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
+{
+    [TestFixture]
+    internal class WhenCreatingAFailedResponseToARequestWithReplyToSessionIdSet : GivenABrokeredMessageFactory
+    {
+        private BrokeredMessage _request;
+        private BrokeredMessage _response;
+        private string _sessionId;
+
+        protected override async Task When()
+        {
+            _request = new BrokeredMessage();
+            _sessionId = Guid.NewGuid().ToString();
+            _request.ReplyToSessionId = _sessionId;
+            _response = await Subject.CreateFailedResponse(_request, new Exception());
+        }
+
+        [Test]
+        public void ThenTheResponseShouldUseThatSessionId()
+        {
+            _response.SessionId.ShouldBe(_sessionId);
+        }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdNotSet.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdNotSet.cs
@@ -1,0 +1,30 @@
+﻿using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
+{
+    [TestFixture]
+    internal class WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdNotSet : GivenABrokeredMessageFactory
+    {
+        private BrokeredMessage _request;
+        private BrokeredMessage _response;
+
+        protected override async Task When()
+        {
+            _request = new BrokeredMessage();
+            _response = await Subject.CreateSuccessfulResponse(new TestResponse(), _request);
+        }
+
+        [Test]
+        public void ThenTheResponseShouldNotHaveSessionIdSet()
+        {
+            _response.SessionId.ShouldBe(null);
+        }
+
+        [DataContract]
+        public class TestResponse { }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdSet.cs
+++ b/src/Tests/Nimbus.UnitTests/BrokeredMessageFactoryTests/WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdSet.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Microsoft.ServiceBus.Messaging;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.UnitTests.BrokeredMessageFactoryTests
+{
+    [TestFixture]
+    internal class WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdSet : GivenABrokeredMessageFactory
+    {
+        private BrokeredMessage _request;
+        private BrokeredMessage _response;
+        private string _sessionId;
+
+        protected override async Task When()
+        {
+            _request = new BrokeredMessage();
+            _sessionId = Guid.NewGuid().ToString();
+            _request.ReplyToSessionId = _sessionId;
+            _response = await Subject.CreateSuccessfulResponse(new TestResponse(), _request);
+        }
+
+        [Test]
+        public void ThenTheResponseShouldUseThatSessionId()
+        {
+            _response.SessionId.ShouldBe(_sessionId);
+        }
+
+        [DataContract]
+        public class TestResponse { }
+    }
+}

--- a/src/Tests/Nimbus.UnitTests/Nimbus.UnitTests.csproj
+++ b/src/Tests/Nimbus.UnitTests/Nimbus.UnitTests.csproj
@@ -89,6 +89,10 @@
     <Compile Include="BatchSendingTests\WhenSendingACollectionOfCommandsViaTheCommandSender.cs" />
     <Compile Include="BrokeredMessageFactoryTests\GivenABrokeredMessageFactory.cs" />
     <Compile Include="BrokeredMessageFactoryTests\WhenCreatingANewMessageWithContent.cs" />
+    <Compile Include="BrokeredMessageFactoryTests\WhenCreatingAFailedResponseToARequestWithReplyToSessionIdNotSet.cs" />
+    <Compile Include="BrokeredMessageFactoryTests\WhenCreatingAFailedResponseToARequestWithReplyToSessionIdSet.cs" />
+    <Compile Include="BrokeredMessageFactoryTests\WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdSet.cs" />
+    <Compile Include="BrokeredMessageFactoryTests\WhenCreatingASuccesfulResponseToARequestWithReplyToSessionIdNotSet.cs" />
     <Compile Include="CompressionTests\WhenBuildingBrokeredMessagesUsingCompression.cs" />
     <Compile Include="CompressionTests\WhenUsingDeflateCompressor.cs" />
     <Compile Include="CompressionTests\WhenUsingGzipCompressor.cs" />


### PR DESCRIPTION
BrokeredMessageFactory now adds a SessionID on Response messages to match the ReplyToSessionId attribute set in the original Request.

This achieves 1-way interoperability with non-Nimbus services that conform to the Request-Response pattern conventions recommended on MSDN.

Closes #191
