### PR TITLE
Log4net improvements

### DIFF
--- a/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
+++ b/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
@@ -14,29 +14,40 @@ namespace Nimbus.Logger.Log4net
 
         public void Debug(string format, params object[] args)
         {
-            _log.DebugFormat(format, args);
+            if (args.Length > 0)
+                _log.DebugFormat(format, args);
+            else
+                _log.Debug(format);
         }
 
         public void Info(string format, params object[] args)
         {
-            _log.InfoFormat(format, args);
+            if (args.Length > 0)
+                _log.InfoFormat(format, args);
+            else
+                _log.Info(format);
         }
 
         public void Warn(string format, params object[] args)
         {
-            _log.WarnFormat(format, args);
+            if (args.Length > 0)
+                _log.WarnFormat(format, args);
+            else
+                _log.Warn(format);
         }
 
         public void Error(string format, params object[] args)
         {
-            _log.ErrorFormat(format, args);
+            if (args.Length > 0)
+                _log.ErrorFormat(format, args);
+            else
+                _log.Error(format);
         }
 
         public void Error(Exception exc, string format, params object[] args)
         {
-            var message = String.Format(format, args);
+            var message = (args.Length) > 0 ? String.Format(format, args) : format;
             _log.Error(message, exc);
         }
-
     }
 }

--- a/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
+++ b/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using log4net;
+using Nimbus.Infrastructure.Logging;
 
 namespace Nimbus.Logger.Log4net
 {
@@ -15,7 +16,7 @@ namespace Nimbus.Logger.Log4net
         public void Debug(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.DebugFormat(format, args);
+                _log.DebugFormat(format.NormalizeToStringFormat(), args);
             else
                 _log.Debug(format);
         }
@@ -23,7 +24,7 @@ namespace Nimbus.Logger.Log4net
         public void Info(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.InfoFormat(format, args);
+                _log.InfoFormat(format.NormalizeToStringFormat(), args);
             else
                 _log.Info(format);
         }
@@ -31,7 +32,7 @@ namespace Nimbus.Logger.Log4net
         public void Warn(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.WarnFormat(format, args);
+                _log.WarnFormat(format.NormalizeToStringFormat(), args);
             else
                 _log.Warn(format);
         }
@@ -39,14 +40,14 @@ namespace Nimbus.Logger.Log4net
         public void Error(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.ErrorFormat(format, args);
+                _log.ErrorFormat(format.NormalizeToStringFormat(), args);
             else
                 _log.Error(format);
         }
 
         public void Error(Exception exc, string format, params object[] args)
         {
-            var message = (args.Length) > 0 ? String.Format(format, args) : format;
+            var message = (args.Length) > 0 ? String.Format(format.NormalizeToStringFormat(), args) : format;
             _log.Error(message, exc);
         }
     }

--- a/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
+++ b/src/Extensions/Nimbus.Logger.Log4net/Logger/Log4Net/Log4netLogger.cs
@@ -16,7 +16,7 @@ namespace Nimbus.Logger.Log4net
         public void Debug(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.DebugFormat(format.NormalizeToStringFormat(), args);
+                _log.DebugFormat(StructuredLoggingNormalizer.Normalize(format), args);
             else
                 _log.Debug(format);
         }
@@ -24,7 +24,7 @@ namespace Nimbus.Logger.Log4net
         public void Info(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.InfoFormat(format.NormalizeToStringFormat(), args);
+                _log.InfoFormat(StructuredLoggingNormalizer.Normalize(format), args);
             else
                 _log.Info(format);
         }
@@ -32,7 +32,7 @@ namespace Nimbus.Logger.Log4net
         public void Warn(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.WarnFormat(format.NormalizeToStringFormat(), args);
+                _log.WarnFormat(StructuredLoggingNormalizer.Normalize(format), args);
             else
                 _log.Warn(format);
         }
@@ -40,14 +40,14 @@ namespace Nimbus.Logger.Log4net
         public void Error(string format, params object[] args)
         {
             if (args.Length > 0)
-                _log.ErrorFormat(format.NormalizeToStringFormat(), args);
+                _log.ErrorFormat(StructuredLoggingNormalizer.Normalize(format), args);
             else
                 _log.Error(format);
         }
 
         public void Error(Exception exc, string format, params object[] args)
         {
-            var message = (args.Length) > 0 ? String.Format(format.NormalizeToStringFormat(), args) : format;
+            var message = (args.Length) > 0 ? String.Format(StructuredLoggingNormalizer.Normalize(format), args) : format;
             _log.Error(message, exc);
         }
     }

--- a/src/Nimbus/Extensions/StringExtensions.cs
+++ b/src/Nimbus/Extensions/StringExtensions.cs
@@ -1,10 +1,18 @@
-﻿namespace Nimbus.Extensions
+﻿using System;
+using Nimbus.Infrastructure.Logging;
+
+namespace Nimbus.Extensions
 {
     internal static class StringExtensions
     {
         internal static string FormatWith(this string s, params object[] args)
         {
-            return string.Format(s, args);
+            return String.Format(s, args);
+        }
+
+        internal static string NormalizeToStringFormat(this string format)
+        {
+            return StructuredLoggingNormalizer.Normalize(format);
         }
     }
 }

--- a/src/Nimbus/Infrastructure/Logging/ConsoleLogger.cs
+++ b/src/Nimbus/Infrastructure/Logging/ConsoleLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Nimbus.Extensions;
 
 namespace Nimbus.Infrastructure.Logging
 {

--- a/src/Nimbus/Infrastructure/Logging/StructuredLoggingNormalizer.cs
+++ b/src/Nimbus/Infrastructure/Logging/StructuredLoggingNormalizer.cs
@@ -8,11 +8,6 @@ namespace Nimbus.Infrastructure.Logging
     {
         private static readonly Regex _regex = new Regex(@"{\S+?}", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
-        public static string NormalizeToStringFormat(this string format)
-        {
-            return Normalize(format);
-        }
-
         /// <summary>
         ///     Normalizes a log format string containing named placeholders (e.g. Message: {MessageId}) to a string containing
         ///     only

--- a/src/Nimbus/Infrastructure/Logging/StructuredLoggingNormalizer.cs
+++ b/src/Nimbus/Infrastructure/Logging/StructuredLoggingNormalizer.cs
@@ -4,11 +4,11 @@ using Nimbus.Extensions;
 
 namespace Nimbus.Infrastructure.Logging
 {
-    internal static class StructuredLoggingNormalizer
+    public static class StructuredLoggingNormalizer
     {
         private static readonly Regex _regex = new Regex(@"{\S+?}", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
 
-        internal static string NormalizeToStringFormat(this string format)
+        public static string NormalizeToStringFormat(this string format)
         {
             return Normalize(format);
         }

--- a/src/Tests/Nimbus.UnitTests/LoggingTests/TemplateNormalization/WhenNormalizingStructuredLogTemplates.cs
+++ b/src/Tests/Nimbus.UnitTests/LoggingTests/TemplateNormalization/WhenNormalizingStructuredLogTemplates.cs
@@ -1,4 +1,5 @@
-﻿using Nimbus.Infrastructure.Logging;
+﻿using Nimbus.Extensions;
+using Nimbus.Infrastructure.Logging;
 using NUnit.Framework;
 using Shouldly;
 


### PR DESCRIPTION
We found in production that we were getting warnings in Log4Net because it couldn't understand Serilog string formats. So, we've added log message normalisation to the Log4Net logger implementation, which required some change to the infrastructure to expose the normalize() method to extensions.