### PR TITLE
Add DispatchAbandoned property to avoid MessageLockLostException

### DIFF
--- a/src/Nimbus/Infrastructure/LongRunningTasks/LongRunningTaskWrapperBase.cs
+++ b/src/Nimbus/Infrastructure/LongRunningTasks/LongRunningTaskWrapperBase.cs
@@ -111,6 +111,13 @@ namespace Nimbus.Infrastructure.LongRunningTasks
                     return;
                 }
 
+                object dispatchAbandoned;
+                if (message.Properties.TryGetValue(MessagePropertyKeys.DispatchAbandoned, out dispatchAbandoned) && dispatchAbandoned as bool? == true)
+                {
+                    //_logger.Debug("Long-running task wrapper awoke after message {0} had already been dispatched. Nothing to see here.", message.MessageId);
+                    return;
+                }
+
                 _logger.Info(
                     "Long-running handler {HandlerType} for message {MessageId} requires a lock renewal ({LockTimeRemaining} seconds remaining; {LockTimeRequired} required).",
                     longRunningHandler.GetType().FullName,

--- a/src/Nimbus/Infrastructure/MessagePropertyKeys.cs
+++ b/src/Nimbus/Infrastructure/MessagePropertyKeys.cs
@@ -18,6 +18,7 @@
         public const string SentToQueue = "SentToQueue";
         public const string SentToTopic = "SentToTopic";
         public const string DispatchComplete = "DispatchComplete";
+        public const string DispatchAbandoned = "DispatchAbandoned";
         public const string PrecedingMessageId = "PrecedingMessageId";
     }
 }

--- a/src/Nimbus/Infrastructure/MessagePump.cs
+++ b/src/Nimbus/Infrastructure/MessagePump.cs
@@ -134,6 +134,7 @@ namespace Nimbus.Infrastructure
                 try
                 {
                     LogDebug("Abandoning", message);
+                    message.Properties[MessagePropertyKeys.DispatchAbandoned] = true;
                     await message.AbandonAsync(exception.ExceptionDetailsAsProperties(_clock.UtcNow));
                     LogDebug("Abandoned", message);
                 }


### PR DESCRIPTION
When using ILongRunningTask, if an exception is thrown in the Handle method, the lock renewal will fail with a MessageLockLostException. This doesn't occur when a message completes because a check is made on the message for property MessagePropertyKeys.DispatchComplete. I thought to avoid the MessageLockLostException for abandoned messages by adding a MessagePropertyKeys.DispatchAbandoned property.