### PR TITLE
Azure claim settings

### DIFF
--- a/src/Nimbus/Bus.cs
+++ b/src/Nimbus/Bus.cs
@@ -116,10 +116,15 @@ namespace Nimbus
 
                 await _messagePumpsManager.Start(messagePumpTypes);
             }
-            catch (Exception aex)
+            catch (AggregateException aex)
             {
                 _logger.Error(aex, "Failed to start bus.");
                 throw new BusException("Failed to start bus", aex);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to start bus.");
+                throw new BusException("Failed to stop bus", ex);
             }
 
             var startedHandler = Started;
@@ -145,9 +150,13 @@ namespace Nimbus
 
                 await _messagePumpsManager.Stop(messagePumpTypes);
             }
-            catch (Exception aex)
+            catch (AggregateException aex)
             {
                 throw new BusException("Failed to stop bus", aex);
+            }
+            catch (Exception ex)
+            {
+                throw new BusException("Failed to stop bus", ex);
             }
 
             var stoppedHandler = Stopped;

--- a/src/Nimbus/Bus.cs
+++ b/src/Nimbus/Bus.cs
@@ -116,7 +116,7 @@ namespace Nimbus
 
                 await _messagePumpsManager.Start(messagePumpTypes);
             }
-            catch (AggregateException aex)
+            catch (Exception aex)
             {
                 _logger.Error(aex, "Failed to start bus.");
                 throw new BusException("Failed to start bus", aex);
@@ -145,7 +145,7 @@ namespace Nimbus
 
                 await _messagePumpsManager.Stop(messagePumpTypes);
             }
-            catch (AggregateException aex)
+            catch (Exception aex)
             {
                 throw new BusException("Failed to stop bus", aex);
             }

--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -43,7 +43,7 @@ namespace Nimbus.Configuration
         internal ConcurrentHandlerLimitSetting DefaultConcurrentHandlerLimit { get; set; }
         internal MaximumThreadPoolThreadsSetting MaximumThreadPoolThreads { get; set; }
         internal MinimumThreadPoolThreadsSetting MinimumThreadPoolThreads { get; set; }
-        internal HasAzureManageClaimSetting DefaultAutoSpinUpQueuesAndTopics { get; set; }
+        internal SuppressQueuesAndTopicCreationSetting SupressQueueAndTopicCreation { get; set; }
 
         internal BusBuilderConfiguration()
         {

--- a/src/Nimbus/Configuration/BusBuilderConfiguration.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfiguration.cs
@@ -43,6 +43,7 @@ namespace Nimbus.Configuration
         internal ConcurrentHandlerLimitSetting DefaultConcurrentHandlerLimit { get; set; }
         internal MaximumThreadPoolThreadsSetting MaximumThreadPoolThreads { get; set; }
         internal MinimumThreadPoolThreadsSetting MinimumThreadPoolThreads { get; set; }
+        internal HasAzureManageClaimSetting DefaultAutoSpinUpQueuesAndTopics { get; set; }
 
         internal BusBuilderConfiguration()
         {

--- a/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
@@ -109,25 +109,25 @@ namespace Nimbus.Configuration
 
         public static BusBuilderConfiguration WithDefaultMessageTimeToLive(this BusBuilderConfiguration configuration, TimeSpan timeToLive)
         {
-            configuration.DefaultMessageTimeToLive = new DefaultMessageTimeToLiveSetting { Value = timeToLive };
+            configuration.DefaultMessageTimeToLive = new DefaultMessageTimeToLiveSetting {Value = timeToLive};
             return configuration;
         }
 
         public static BusBuilderConfiguration WithAutoDeleteOnIdle(this BusBuilderConfiguration configuration, TimeSpan autoDeleteOnIdle)
         {
-            configuration.AutoDeleteOnIdle = new AutoDeleteOnIdleSetting { Value = autoDeleteOnIdle };
+            configuration.AutoDeleteOnIdle = new AutoDeleteOnIdleSetting {Value = autoDeleteOnIdle};
             return configuration;
         }
 
         public static BusBuilderConfiguration WithEnableDeadLetteringOnMessageExpiration(this BusBuilderConfiguration configuration, bool enableDeadLettering)
         {
-            configuration.EnableDeadLetteringOnMessageExpiration = new EnableDeadLetteringOnMessageExpirationSetting { Value = enableDeadLettering };
+            configuration.EnableDeadLetteringOnMessageExpiration = new EnableDeadLetteringOnMessageExpirationSetting {Value = enableDeadLettering};
             return configuration;
         }
 
         public static BusBuilderConfiguration WithHeartbeatInterval(this BusBuilderConfiguration configuration, TimeSpan heartbeatInterval)
         {
-            configuration.HeartbeatInterval = new HeartbeatIntervalSetting { Value = heartbeatInterval };
+            configuration.HeartbeatInterval = new HeartbeatIntervalSetting {Value = heartbeatInterval};
             return configuration;
         }
 
@@ -153,6 +153,12 @@ namespace Nimbus.Configuration
                                                                Func<BusBuilderDebuggingConfiguration, BusBuilderDebuggingConfiguration> debugConfiguration)
         {
             debugConfiguration(configuration.Debugging);
+            return configuration;
+        }
+
+        public static BusBuilderConfiguration WithAzureManageClaim(this BusBuilderConfiguration configuration, bool hasAzureManageClaim)
+        {
+            configuration.DefaultAutoSpinUpQueuesAndTopics = new HasAzureManageClaimSetting() { Value = hasAzureManageClaim };
             return configuration;
         }
     }

--- a/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
+++ b/src/Nimbus/Configuration/BusBuilderConfigurationExtensions.cs
@@ -156,9 +156,9 @@ namespace Nimbus.Configuration
             return configuration;
         }
 
-        public static BusBuilderConfiguration WithAzureManageClaim(this BusBuilderConfiguration configuration, bool hasAzureManageClaim)
+        public static BusBuilderConfiguration SupressQueueAndTopicCreation(this BusBuilderConfiguration configuration, bool suppressQueueAndTopicCreation)
         {
-            configuration.DefaultAutoSpinUpQueuesAndTopics = new HasAzureManageClaimSetting() { Value = hasAzureManageClaim };
+            configuration.SupressQueueAndTopicCreation = new SuppressQueuesAndTopicCreationSetting() { Value = suppressQueueAndTopicCreation };
             return configuration;
         }
     }

--- a/src/Nimbus/Configuration/Settings/HasAzureManageClaimSetting.cs
+++ b/src/Nimbus/Configuration/Settings/HasAzureManageClaimSetting.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nimbus.Configuration.Settings
 {
-    internal class HasAzureManageClaimSetting : Setting<bool>
+    public class HasAzureManageClaimSetting : Setting<bool>
     {
         public override bool Default
         {

--- a/src/Nimbus/Configuration/Settings/HasAzureManageClaimSetting.cs
+++ b/src/Nimbus/Configuration/Settings/HasAzureManageClaimSetting.cs
@@ -1,0 +1,10 @@
+﻿namespace Nimbus.Configuration.Settings
+{
+    internal class HasAzureManageClaimSetting : Setting<bool>
+    {
+        public override bool Default
+        {
+            get { return true; }
+        }
+    }
+}

--- a/src/Nimbus/Configuration/Settings/SuppressQueuesAndTopicCreationSetting.cs
+++ b/src/Nimbus/Configuration/Settings/SuppressQueuesAndTopicCreationSetting.cs
@@ -1,10 +1,10 @@
 ﻿namespace Nimbus.Configuration.Settings
 {
-    public class HasAzureManageClaimSetting : Setting<bool>
+    public class SuppressQueuesAndTopicCreationSetting : Setting<bool>
     {
         public override bool Default
         {
-            get { return true; }
+            get { return false; }
         }
     }
 }

--- a/src/Nimbus/Infrastructure/AzureQueueManager.cs
+++ b/src/Nimbus/Infrastructure/AzureQueueManager.cs
@@ -60,19 +60,12 @@ namespace Nimbus.Infrastructure
 
         public void WarmUp()
         {
-            try
-            {
-                // ReSharper disable UnusedVariable
-                var task0 = Task.Run(() => { var dummy0 = _knownQueues.Value; });
-                var task1 = Task.Run(() => { var dummy1 = _knownSubscriptions.Value; });
-                // ReSharper restore UnusedVariable
+            // ReSharper disable UnusedVariable
+            var task0 = Task.Run(() => { var dummy0 = _knownQueues.Value; });
+            var task1 = Task.Run(() => { var dummy1 = _knownSubscriptions.Value; });
+            // ReSharper restore UnusedVariable
 
-                Task.WaitAll(task0, task1);
-            }
-            catch (Exception exc)
-            {
-                throw new BusException("Azure queue manager failed to start", exc);
-            }
+            Task.WaitAll(task0, task1);
         }
 
         public Task<MessageSender> CreateMessageSender(string queuePath)

--- a/src/Nimbus/Infrastructure/AzureQueueManager.cs
+++ b/src/Nimbus/Infrastructure/AzureQueueManager.cs
@@ -94,7 +94,7 @@ namespace Nimbus.Infrastructure
                 catch (Exception ex)
                 {
                     throw new BusException(
-                        string.Format("Queue={0} doesn't exist. Azure Manage claim needed or queue, topics and subscriptions will have to be manually created.",
+                        string.Format("Queue={0} doesn't exist. Azure Manage claim is needed otherwise queue, topics and subscriptions will have to be manually created.",
                                       queuePath), ex);
                 }
             }
@@ -114,7 +114,7 @@ namespace Nimbus.Infrastructure
                 catch (Exception ex)
                 {
                     throw new BusException(
-                        string.Format("Topic={0} doesn't exist.Azure Manage claim needed or queue, topics and subscriptions will have to be manually created.",
+                        string.Format("Topic={0} doesn't exist.Azure Manage claim is needed otherwise queue, topics and subscriptions will have to be manually created.",
                                       topicPath), ex);
                 }
             }
@@ -137,7 +137,7 @@ namespace Nimbus.Infrastructure
                 catch (Exception ex)
                 {
                     throw new BusException(
-                        string.Format("Subscription={0} for topic={1} doesn't exist.Azure Manage claim needed or queue, topics and subscriptions will have to be manually created.",
+                        string.Format("Subscription={0} for topic={1} doesn't exist.Azure Manage claim is needed otherwise queue, topics and subscriptions will have to be manually created.",
                                       subscriptionName,
                                       topicPath), ex);
                 }

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Configuration\Settings\EnableDeadLetteringOnMessageExpirationSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalInboundInterceptorTypesSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalOutboundInterceptorTypesSetting.cs" />
+    <Compile Include="Configuration\Settings\HasAzureManageClaimSetting.cs" />
     <Compile Include="Configuration\Settings\HeartbeatInterval.cs" />
     <Compile Include="Configuration\Settings\ServerConnectionCountSetting.cs" />
     <Compile Include="Configuration\Settings\SubscriptionAutoDeleteOnIdleSetting.cs" />

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>95852eb7</NuGetPackageImportStamp>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,7 +83,7 @@
     <Compile Include="Configuration\Settings\EnableDeadLetteringOnMessageExpirationSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalInboundInterceptorTypesSetting.cs" />
     <Compile Include="Configuration\Settings\GlobalOutboundInterceptorTypesSetting.cs" />
-    <Compile Include="Configuration\Settings\HasAzureManageClaimSetting.cs" />
+    <Compile Include="Configuration\Settings\SuppressQueuesAndTopicCreationSetting.cs" />
     <Compile Include="Configuration\Settings\HeartbeatInterval.cs" />
     <Compile Include="Configuration\Settings\ServerConnectionCountSetting.cs" />
     <Compile Include="Configuration\Settings\SubscriptionAutoDeleteOnIdleSetting.cs" />
@@ -260,7 +262,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.1.25.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.25.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Samples/PizzaSample/Pizza.Maker/Program.cs
+++ b/src/Samples/PizzaSample/Pizza.Maker/Program.cs
@@ -48,7 +48,7 @@ namespace Pizza.Maker
             var typeProvider = new AssemblyScanningTypeProvider(Assembly.GetExecutingAssembly(),
                                                                 typeof (OrderPizzaCommand).Assembly,
                                                                 typeof (NewOrderRecieved).Assembly);
-
+            
             builder.RegisterNimbus(typeProvider);
             builder.Register(componentContext => new BusBuilder()
                                  .Configure()
@@ -56,6 +56,7 @@ namespace Pizza.Maker
                                  .WithNames("Maker", Environment.MachineName)
                                  .WithTypesFrom(typeProvider)
                                  .WithAutofacDefaults(componentContext)
+                                 .WithAzureManageClaim(true)
                                  .Build())
                    .As<IBus>()
                    .AutoActivate()

--- a/src/Samples/PizzaSample/Pizza.Maker/Program.cs
+++ b/src/Samples/PizzaSample/Pizza.Maker/Program.cs
@@ -56,7 +56,7 @@ namespace Pizza.Maker
                                  .WithNames("Maker", Environment.MachineName)
                                  .WithTypesFrom(typeProvider)
                                  .WithAutofacDefaults(componentContext)
-                                 .WithAzureManageClaim(true)
+                                 .SupressQueueAndTopicCreation(true)
                                  .Build())
                    .As<IBus>()
                    .AutoActivate()


### PR DESCRIPTION
Hi guys, this is an idea on how to handle Azure claim settings so that if you can't have manage access (ie in production environment) you can switch that off, create your queue topics manually and run Nimbus without it crashing.
You can configure a HasAzureManageClaimSetting property in your bus configuration. Default value is true. When it's set to true everything's like before. When it's set to false if queues/topics/subscriptions are not there an exception is thrown.
About how to spit out the list of required queues/topics/subs to hand over to the devops guys I was maybe thinking during the warmup to log them out, but not sure... (this is not done yet).
What do you think? Cheers

NB I have included in this pull request my previous one (https://github.com/NimbusAPI/Nimbus/pull/207) cause I needed that to be fixed to get this one done.
