### PR TITLE
Add property injection to Request and MulticastRequest dispatchers

### DIFF
--- a/src/Nimbus/Infrastructure/MessageDispatcherFactory.cs
+++ b/src/Nimbus/Infrastructure/MessageDispatcherFactory.cs
@@ -107,7 +107,8 @@ namespace Nimbus.Infrastructure
                                                     _messagingFactory,
                                                     handlerMap,
                                                     _defaultMessageLockDuration,
-                                                    _taskFactory);
+                                                    _taskFactory,
+                                                    _propertyInjector);
             }
 
             if (openGenericHandlerType == typeof (IHandleMulticastRequest<,>))
@@ -121,7 +122,8 @@ namespace Nimbus.Infrastructure
                                                              _outboundInterceptorFactory,
                                                              handlerMap,
                                                              _defaultMessageLockDuration,
-                                                             _taskFactory);
+                                                             _taskFactory,
+                                                             _propertyInjector);
             }
 
             throw new NotSupportedException("There is no dispatcher for the handler type {0}.".FormatWith(openGenericHandlerType.FullName));

--- a/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessageDispatcher.cs
+++ b/src/Nimbus/Infrastructure/RequestResponse/MulticastRequestMessageDispatcher.cs
@@ -9,6 +9,7 @@ using Nimbus.DependencyResolution;
 using Nimbus.Extensions;
 using Nimbus.Handlers;
 using Nimbus.Infrastructure.LongRunningTasks;
+using Nimbus.Infrastructure.PropertyInjection;
 using Nimbus.Infrastructure.TaskScheduling;
 using Nimbus.Interceptors.Inbound;
 using Nimbus.Interceptors.Outbound;
@@ -28,6 +29,7 @@ namespace Nimbus.Infrastructure.RequestResponse
         private readonly IReadOnlyDictionary<Type, Type[]> _handlerMap;
         private readonly DefaultMessageLockDurationSetting _defaultMessageLockDuration;
         private readonly INimbusTaskFactory _taskFactory;
+        private readonly IPropertyInjector _propertyInjector;
 
         public MulticastRequestMessageDispatcher(IBrokeredMessageFactory brokeredMessageFactory,
                                                  IClock clock,
@@ -38,7 +40,8 @@ namespace Nimbus.Infrastructure.RequestResponse
                                                  IOutboundInterceptorFactory outboundInterceptorFactory,
                                                  IReadOnlyDictionary<Type, Type[]> handlerMap,
                                                  DefaultMessageLockDurationSetting defaultMessageLockDuration,
-                                                 INimbusTaskFactory taskFactory)
+                                                 INimbusTaskFactory taskFactory,
+                                                 IPropertyInjector propertyInjector)
         {
             _brokeredMessageFactory = brokeredMessageFactory;
             _clock = clock;
@@ -49,6 +52,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             _handlerMap = handlerMap;
             _defaultMessageLockDuration = defaultMessageLockDuration;
             _taskFactory = taskFactory;
+            _propertyInjector = propertyInjector;
             _outboundInterceptorFactory = outboundInterceptorFactory;
         }
 
@@ -75,6 +79,7 @@ namespace Nimbus.Infrastructure.RequestResponse
             using (var scope = _dependencyResolver.CreateChildScope())
             {
                 var handler = (IHandleMulticastRequest<TBusRequest, TBusResponse>)scope.Resolve(handlerType);
+                _propertyInjector.Inject(handler, brokeredMessage);
                 var inboundInterceptors = _inboundInterceptorFactory.CreateInterceptors(scope, handler, busRequest, brokeredMessage);
 
                 foreach (var interceptor in inboundInterceptors)

--- a/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
+++ b/src/Tests/Nimbus.UnitTests/DispatcherTests/MessageDispatcherTestBase.cs
@@ -78,7 +78,8 @@ namespace Nimbus.UnitTests.DispatcherTests
                 messagingFactory,
                 HandlerMapper.GetFullHandlerMap(typeof (IHandleRequest<,>)),
                 new DefaultMessageLockDurationSetting(),
-                _taskFactory);
+                _taskFactory,
+                Substitute.For<IPropertyInjector>());
         }
 
         internal CommandMessageDispatcher GetCommandMessageDispatcher<TCommand, TCommandHandler>(IInboundInterceptor interceptor)


### PR DESCRIPTION
__Commit https://github.com/NimbusAPI/Nimbus/commit/31f245d054130f817ac07ba20e4c389163aee6c3__
Rename argument of `CommandMessageDispatcher.Dispatch` method from `message` to `brokeredMessage`.
I did this because it is named `brokeredMessage` in all of the other message dispatchers.

__Commit https://github.com/NimbusAPI/Nimbus/commit/9cfd5975b4355454d3c04f08de5a2f9a8b5a4395__
After resolving a handler, `CommandMessageDispatcher`, `CompetingEventMessageDispatcher`, and `MulticastEventMessageDispatcher` all call the `Inject` method of an `IPropertyInjector`, which injects properties such as `IRequireBus` and `IRequireBrokeredMessage`, etc.
This commit changes `RequestMessageDispatcher` and `MulticastRequestMessageDispatcher` to do the same thing.
It also updates the `MessageDispatcherFactory` and `MessageDispatcherTestBase` accordingly.  

I can see the obvious pattern of _everything except request handlers get property injected_, which makes me wonder if there is a reason? If so, please let me know. If not, can you please consider merging this?

Thanks!