### PR TITLE
Azure Service Bus Transport failures on Event Handler Exception

### DIFF
--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/QueueManagement/AzureQueueManager.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/QueueManagement/AzureQueueManager.cs
@@ -208,6 +208,22 @@ namespace Nimbus.Transports.WindowsServiceBus.QueueManagement
                              "Fetching existing queues");
         }
 
+        public Task<bool> ExistingTopic(string topicPath)
+        {
+            return Task.Run(() =>
+            {
+                return _knownTopics.Value.Contains(topicPath);
+            }).ConfigureAwaitFalse();
+        }
+
+        public Task<bool> ExistingQueue(string queuePath)
+        {
+            return Task.Run(() =>
+            {
+                return _knownQueues.Value.Contains(queuePath);
+            }).ConfigureAwaitFalse();
+        }
+
         private void EnsureTopicExists(string topicPath)
         {
             if (_knownTopics.Value.Contains(topicPath)) return;

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/QueueManagement/IQueueManager.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/QueueManagement/IQueueManager.cs
@@ -17,5 +17,8 @@ namespace Nimbus.Transports.WindowsServiceBus.QueueManagement
 
         Task<MessageSender> CreateDeadQueueMessageSender();
         Task<MessageReceiver> CreateDeadQueueMessageReceiver();
+
+        Task<bool> ExistingTopic(string topicPath);
+        Task<bool> ExistingQueue(string queuePath);
     }
 }

--- a/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
+++ b/src/Tests/Nimbus.IntegrationTests/Nimbus.IntegrationTests.csproj
@@ -158,8 +158,11 @@
     <Compile Include="Tests\MulticastRequestResponseTests\WhenSendingAMulticastRequestThatShouldAllowAllResponders.cs" />
     <Compile Include="Tests\PoisonMessageTests\CommandHandlers\GoBangCommandHandler.cs" />
     <Compile Include="Tests\PoisonMessageTests\DeadLetterOfficeExtensions.cs" />
+    <Compile Include="Tests\PoisonMessageTests\EventHandlers\GoBangEventHandler.cs" />
     <Compile Include="Tests\PoisonMessageTests\MessageContracts\GoBangCommand.cs" />
+    <Compile Include="Tests\PoisonMessageTests\MessageContracts\GoBangEvent.cs" />
     <Compile Include="Tests\PoisonMessageTests\WhenACommandFailsToBeHandledMoreThanNTimes.cs" />
+    <Compile Include="Tests\PoisonMessageTests\WhenAnEventFailsToBeHandledMoreThanNTimes.cs" />
     <Compile Include="Tests\SimpleCommandSendingTests\CommandHandlers\SomeOtherCommandHandler.cs" />
     <Compile Include="Tests\SimpleCommandSendingTests\MessageContracts\SomeOtherCommand.cs" />
     <Compile Include="Tests\SimpleCommandSendingTests\MessageContracts\SomeCommandThatHasNoHandler.cs" />

--- a/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/EventHandlers/GoBangEventHandler.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/EventHandlers/GoBangEventHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Threading.Tasks;
+using Nimbus.Handlers;
+using Nimbus.IntegrationTests.Tests.PoisonMessageTests.MessageContracts;
+using Nimbus.Tests.Common.TestUtilities;
+
+namespace Nimbus.IntegrationTests.Tests.PoisonMessageTests.EventHandlers
+{
+    public class GoBangCompetingEventHandler : IHandleCompetingEvent<GoBangEvent>
+    {
+        public async Task Handle(GoBangEvent busEvent)
+        {
+            MethodCallCounter.RecordCall<GoBangCompetingEventHandler>(h => h.Handle(busEvent));
+
+            throw new Exception("This handler is supposed to fail.");
+        }
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/MessageContracts/GoBangEvent.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/MessageContracts/GoBangEvent.cs
@@ -1,0 +1,18 @@
+﻿using Nimbus.MessageContracts;
+
+namespace Nimbus.IntegrationTests.Tests.PoisonMessageTests.MessageContracts
+{
+    public class GoBangEvent : IBusEvent
+    {
+        public string SomeContent { get; set; }
+
+        public GoBangEvent()
+        {
+        }
+
+        public GoBangEvent(string someContent)
+        {
+            SomeContent = someContent;
+        }
+    }
+}

--- a/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/WhenAnEventFailsToBeHandledMoreThanNTimes.cs
+++ b/src/Tests/Nimbus.IntegrationTests/Tests/PoisonMessageTests/WhenAnEventFailsToBeHandledMoreThanNTimes.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Nimbus.Configuration;
+using Nimbus.IntegrationTests.Tests.PoisonMessageTests.MessageContracts;
+using Nimbus.Tests.Common.Extensions;
+using Nimbus.Tests.Common.TestScenarioGeneration.ScenarioComposition;
+using Nimbus.Tests.Common.TestScenarioGeneration.TestCaseSources;
+using Nimbus.Tests.Common.TestUtilities;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Nimbus.IntegrationTests.Tests.PoisonMessageTests
+{
+    [TestFixture]
+    public class WhenAnEventFailsToBeHandledMoreThanNTimes : TestForBus
+    {
+        private GoBangEvent _goBangEvent;
+        private string _someContent;
+        private NimbusMessage[] _deadLetterMessages;
+
+        private int _maxDeliveryAttempts;
+
+        protected override async Task Given(IConfigurationScenario<BusBuilderConfiguration> scenario)
+        {
+            await base.Given(scenario);
+            _maxDeliveryAttempts = Instance.Configuration.MaxDeliveryAttempts;
+        }
+
+        protected override async Task When()
+        {
+            _someContent = Guid.NewGuid().ToString();
+            _goBangEvent = new GoBangEvent(_someContent);
+
+            await Bus.Publish(_goBangEvent);
+            await Timeout.WaitUntil(() => MethodCallCounter.AllReceivedCalls.Count() >= _maxDeliveryAttempts);
+
+            _deadLetterMessages = await Bus.DeadLetterOffice.PopAll(1, TimeSpan.FromSeconds(TimeoutSeconds));
+        }
+
+        [Test]
+        [TestCaseSource(typeof(AllBusConfigurations<WhenAnEventFailsToBeHandledMoreThanNTimes>))]
+        public async Task Run(string testName, IConfigurationScenario<BusBuilderConfiguration> scenario)
+        {
+            await Given(scenario);
+            await When();
+            await Then();
+        }
+
+        [Then]
+        public async Task ThereShouldBeExactlyOneMessageOnTheDeadLetterQueue()
+        {
+            _deadLetterMessages.Count().ShouldBe(1);
+        }
+
+        [Then]
+        public async Task ThePayloadOfTheMessageShouldBeTheOriginalCommandThatWentBang()
+        {
+            ((GoBangEvent)_deadLetterMessages.Single().Payload).SomeContent.ShouldBe(_someContent);
+        }
+
+        [Then]
+        public async Task TheMessageShouldHaveTheCorrectNumberOfDeliveryAttempts()
+        {
+            var nimbusMessage = _deadLetterMessages.Single();
+            nimbusMessage.DeliveryAttempts.Count().ShouldBe(_maxDeliveryAttempts);
+        }
+    }
+}

--- a/src/Tests/Nimbus.Tests.Common/TestScenarioGeneration/ConfigurationSources/Transports/WindowsServiceBus.cs
+++ b/src/Tests/Nimbus.Tests.Common/TestScenarioGeneration/ConfigurationSources/Transports/WindowsServiceBus.cs
@@ -18,6 +18,11 @@ namespace Nimbus.Tests.Common.TestScenarioGeneration.ConfigurationSources.Transp
             _largeMessageScenario = largeMessageScenario;
         }
 
+        public WindowsServiceBus()
+        {
+            _largeMessageScenario = null;
+        }
+
         protected override IEnumerable<string> AdditionalCategories
         {
             get { yield return "Slow"; }
@@ -25,12 +30,15 @@ namespace Nimbus.Tests.Common.TestScenarioGeneration.ConfigurationSources.Transp
 
         public ScenarioInstance<TransportConfiguration> CreateInstance()
         {
-            var largeMessageStorageInstance = _largeMessageScenario.CreateInstance();
-
             var azureServiceBusConnectionString = DefaultSettingsReader.Get<AzureServiceBusConnectionString>();
             var configuration = new WindowsServiceBusTransportConfiguration()
-                .WithConnectionString(azureServiceBusConnectionString)
-                .WithLargeMessageStorage(largeMessageStorageInstance.Configuration);
+                .WithConnectionString(azureServiceBusConnectionString);
+
+            if(_largeMessageScenario != null)
+            {
+                var largeMessageStorageInstance = _largeMessageScenario.CreateInstance();
+                configuration.WithLargeMessageStorage(largeMessageStorageInstance.Configuration);
+            }
 
             var instance = new ScenarioInstance<TransportConfiguration>(configuration);
 


### PR DESCRIPTION
Ref #251 .

When a handler that is processing a competing event throws an exception, the current code travels to the DeliverAfter within the transport. This is making the assumption that it is a queue, which in the WSB/ASB extension it looks to create if it does not exist - however for an event that is published it is a topic.  That seems to be the root cause of the exceptions in the logs where it is trying to create a queue for an already existing topic.

An integration test has been added to cover the scenario.  I have run them against an azure service bus subscription to validate that it will go into the dead letter queue, etc.