### PR TITLE
Transport Configuration not able to start the service bus:  Den…

### DIFF
--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/WindowsServiceBusTransportConfiguration.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/WindowsServiceBusTransportConfiguration.cs
@@ -17,6 +17,7 @@ using Nimbus.Transports.WindowsServiceBus.DeadLetterOffice;
 using Nimbus.Transports.WindowsServiceBus.DelayedDelivery;
 using Nimbus.Transports.WindowsServiceBus.Extensions;
 using Nimbus.Transports.WindowsServiceBus.QueueManagement;
+using Nimbus.Transports.WindowsServiceBus.Filtering;
 
 namespace Nimbus.Transports.WindowsServiceBus
 {
@@ -63,6 +64,7 @@ namespace Nimbus.Transports.WindowsServiceBus
             container.RegisterType<DelayedDeliveryService>(ComponentLifetime.SingleInstance, typeof (IDelayedDeliveryService));
             container.RegisterType<WindowsServiceBusDeadLetterOffice>(ComponentLifetime.SingleInstance, typeof (IDeadLetterOffice));
             container.RegisterType<NamespaceCleanser>(ComponentLifetime.SingleInstance, typeof (INamespaceCleanser));
+            container.RegisterType<SqlFilterExpressionGenerator>(ComponentLifetime.SingleInstance, typeof(ISqlFilterExpressionGenerator));
 
             container.Register(c =>
                                {


### PR DESCRIPTION

Issue : 
DencyResolutionException: No registration for type Nimbus.Transports.WindowsServiceBus.Filtering.ISqlFilterExpressionGenerator

Fix :Nimbus.Transports.WindowsServiceBus
WindowsServiceBusTransportConfiguration.cs added SqlFilterExpressionGenerator as SingleInstance
