### PR TITLE
Avoid raising unnecessary ObjectDisposedException when accessing SemaphoreSlim object

### DIFF
--- a/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusQueueMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusQueueMessageReceiver.cs
@@ -3,11 +3,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 using Nimbus.Configuration.Settings;
+using Nimbus.Extensions;
 using Nimbus.Infrastructure;
 using Nimbus.Infrastructure.MessageSendersAndReceivers;
 using Nimbus.Transports.AzureServiceBus.BrokeredMessages;
 using Nimbus.Transports.AzureServiceBus.QueueManagement;
-using Nimbus.Extensions;
 
 namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
 {
@@ -48,7 +48,7 @@ namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
         {
             try
             {
-                if (!cancellationSemaphore.IsDisposed())
+                if (!cancellationSemaphore.IsDisposedOrNull())
                 {
                     await cancellationSemaphore.WaitAsync(cancellationToken);
                 }

--- a/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusQueueMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusQueueMessageReceiver.cs
@@ -48,9 +48,15 @@ namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
         {
             try
             {
-                await cancellationSemaphore.WaitAsync(cancellationToken);
+                if (!cancellationSemaphore.IsDisposed())
+                {
+                    await cancellationSemaphore.WaitAsync(cancellationToken);
+                }
             }
             catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
             {
             }
         }

--- a/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusSubscriptionMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusSubscriptionMessageReceiver.cs
@@ -1,17 +1,13 @@
 using System;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 using Nimbus.Configuration.Settings;
 using Nimbus.Extensions;
-using Nimbus.Filtering.Attributes;
 using Nimbus.Filtering.Conditions;
 using Nimbus.Infrastructure;
 using Nimbus.Infrastructure.MessageSendersAndReceivers;
 using Nimbus.Transports.AzureServiceBus.BrokeredMessages;
-using Nimbus.Transports.AzureServiceBus.Filtering;
 using Nimbus.Transports.AzureServiceBus.QueueManagement;
 
 namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
@@ -58,7 +54,7 @@ namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
         {
             try
             {
-                if (!cancellationSemaphore.IsDisposed())
+                if (!cancellationSemaphore.IsDisposedOrNull())
                 {
                     await cancellationSemaphore.WaitAsync(cancellationToken);
                 }

--- a/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusSubscriptionMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.AzureServiceBus/SendersAndRecievers/AzureServiceBusSubscriptionMessageReceiver.cs
@@ -58,9 +58,15 @@ namespace Nimbus.Transports.AzureServiceBus.SendersAndRecievers
         {
             try
             {
-                await cancellationSemaphore.WaitAsync(cancellationToken);
+                if (!cancellationSemaphore.IsDisposed())
+                {
+                    await cancellationSemaphore.WaitAsync(cancellationToken);
+                }
             }
             catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
             {
             }
         }

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusQueueMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusQueueMessageReceiver.cs
@@ -48,9 +48,15 @@ namespace Nimbus.Transports.WindowsServiceBus.SendersAndRecievers
         {
             try
             {
-                await cancellationSemaphore.WaitAsync(cancellationToken);
+                if (!cancellationSemaphore.IsDisposed())
+                {
+                    await cancellationSemaphore.WaitAsync(cancellationToken);
+                }
             }
             catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
             {
             }
         }

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusQueueMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusQueueMessageReceiver.cs
@@ -48,7 +48,7 @@ namespace Nimbus.Transports.WindowsServiceBus.SendersAndRecievers
         {
             try
             {
-                if (!cancellationSemaphore.IsDisposed())
+                if (!cancellationSemaphore.IsDisposedOrNull())
                 {
                     await cancellationSemaphore.WaitAsync(cancellationToken);
                 }

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusSubscriptionMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusSubscriptionMessageReceiver.cs
@@ -54,9 +54,15 @@ namespace Nimbus.Transports.WindowsServiceBus.SendersAndRecievers
         {
             try
             {
-                await cancellationSemaphore.WaitAsync(cancellationToken);
+                if (!cancellationSemaphore.IsDisposed())
+                {
+                    await cancellationSemaphore.WaitAsync(cancellationToken);
+                }
             }
             catch (OperationCanceledException)
+            {
+            }
+            catch (ObjectDisposedException)
             {
             }
         }

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusSubscriptionMessageReceiver.cs
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/SendersAndRecievers/WindowsServiceBusSubscriptionMessageReceiver.cs
@@ -54,7 +54,7 @@ namespace Nimbus.Transports.WindowsServiceBus.SendersAndRecievers
         {
             try
             {
-                if (!cancellationSemaphore.IsDisposed())
+                if (!cancellationSemaphore.IsDisposedOrNull())
                 {
                     await cancellationSemaphore.WaitAsync(cancellationToken);
                 }

--- a/src/Nimbus/Extensions/SemaphoreSlimExtensions.cs
+++ b/src/Nimbus/Extensions/SemaphoreSlimExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+
+namespace Nimbus.Extensions
+{
+    internal static class SemaphoreSlimExtensions
+    {
+        private static readonly FieldInfo _lockObjFieldInfo = typeof(SemaphoreSlim).GetField("m_lockObj", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        public static bool IsDisposed(this SemaphoreSlim semaphoreSlim)
+        {
+            if (semaphoreSlim == null)
+            {
+                throw new ArgumentNullException(nameof(semaphoreSlim));
+            }
+
+            return _lockObjFieldInfo.GetValue(semaphoreSlim) == null;
+        }
+    }
+}

--- a/src/Nimbus/Extensions/SemaphoreSlimExtensions.cs
+++ b/src/Nimbus/Extensions/SemaphoreSlimExtensions.cs
@@ -8,7 +8,7 @@ namespace Nimbus.Extensions
     {
         private static readonly FieldInfo _lockObjFieldInfo = typeof(SemaphoreSlim).GetField("m_lockObj", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        public static bool IsDisposed(this SemaphoreSlim semaphoreSlim)
+        internal static bool IsDisposed(this SemaphoreSlim semaphoreSlim)
         {
             if (semaphoreSlim == null)
             {
@@ -16,6 +16,11 @@ namespace Nimbus.Extensions
             }
 
             return _lockObjFieldInfo.GetValue(semaphoreSlim) == null;
+        }
+
+        internal static bool IsDisposedOrNull(this SemaphoreSlim semaphoreSlim)
+        {
+            return semaphoreSlim == null || semaphoreSlim.IsDisposed();
         }
     }
 }

--- a/src/Nimbus/Nimbus.csproj
+++ b/src/Nimbus/Nimbus.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Extensions\ConcurrentBagExtensions.cs" />
     <Compile Include="Extensions\FluentConfigurationExtensions.cs" />
     <Compile Include="Extensions\MemberInfoExtensions.cs" />
+    <Compile Include="Extensions\SemaphoreSlimExtensions.cs" />
     <Compile Include="Infrastructure\Filtering\FilterConditionProvider.cs" />
     <Compile Include="Infrastructure\Filtering\IFilterConditionProvider.cs" />
     <Compile Include="Infrastructure\INimbusTransport.cs" />


### PR DESCRIPTION
Rather than raising unnecessary **ObjectDisposedException**s we can reflect on the **SemaphoreSlim** object and check if it is already disposed. Raising lots of unnecessary exceptions (as can happen here) is expensive and impacts performance. With this change we can avoid those unnecessary exceptions.