### PR TITLE
#279 Make FodyWeavers.xml files "none" instead of "content"

### DIFF
--- a/src/Extensions/Nimbus.Logger.Log4net/Nimbus.Logger.Log4net.csproj
+++ b/src/Extensions/Nimbus.Logger.Log4net/Nimbus.Logger.Log4net.csproj
@@ -44,7 +44,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Nimbus.Logger.Log4net.nuspec">

--- a/src/Extensions/Nimbus.Transports.AzureServiceBus/Nimbus.Transports.AzureServiceBus.csproj
+++ b/src/Extensions/Nimbus.Transports.AzureServiceBus/Nimbus.Transports.AzureServiceBus.csproj
@@ -92,7 +92,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Nimbus.InfrastructureContracts\Nimbus.InfrastructureContracts.csproj">

--- a/src/Extensions/Nimbus.Transports.InProcess/Nimbus.Transports.InProcess.csproj
+++ b/src/Extensions/Nimbus.Transports.InProcess/Nimbus.Transports.InProcess.csproj
@@ -85,7 +85,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets')" />

--- a/src/Extensions/Nimbus.Transports.Redis/Nimbus.Transports.Redis.csproj
+++ b/src/Extensions/Nimbus.Transports.Redis/Nimbus.Transports.Redis.csproj
@@ -89,7 +89,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets')" />

--- a/src/Extensions/Nimbus.Transports.WindowsServiceBus/Nimbus.Transports.WindowsServiceBus.csproj
+++ b/src/Extensions/Nimbus.Transports.WindowsServiceBus/Nimbus.Transports.WindowsServiceBus.csproj
@@ -110,7 +110,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="FodyWeavers.xml" />
+    <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets" Condition="Exists('..\..\packages\Fody.1.29.3\build\dotnet\Fody.targets')" />


### PR DESCRIPTION
Fix for issue #279, Make FodyWeavers.xml files "none" instead of "content" so that they don't end up in the nuget packages and added to the target csproj file. `FodyWeavers.xml` is a build concern not a runtime concern so it shouldn't be in the distributed binaries.
