### PR TITLE
Bump Microsoft.Azure.Servicebus version to support .NET 5

### DIFF
--- a/src/Nimbus.Transports.AzureServiceBus/Nimbus.Transports.AzureServiceBus.csproj
+++ b/src/Nimbus.Transports.AzureServiceBus/Nimbus.Transports.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <ProjectReference Include="..\Nimbus\Nimbus.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="microsoft.azure.servicebus" Version="4.1.2" />
+    <PackageReference Include="microsoft.azure.servicebus" Version="5.1.3" />
   </ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>


### PR DESCRIPTION
Microsoft.Azure.Servicebus 4.x.x throws when used in a .NET 5 project. Upgrading should fix it:
https://stackoverflow.com/questions/63768584/azure-service-bus-send-throws-operation-is-not-valid-due-to-the-current-state

